### PR TITLE
Updated old URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 This is the source for the Rivet documentation site. It is built with [Hugo](https://gohugo.io/), a static site generator written in Go (no Go experience is necessary to edit this site). Development is designed for macOS, but should be possible in other environments. To get started:
 ```
-git clone https://github.iu.edu/UITS/rivet-docs-source.git
-cd rivet-docs-source
-echo "registry=https://npmjs.iu.edu/public/registry" > .npmrc && npm install
+git clone https://github.com/indiana-university/rivet-docs.git
+cd rivet-docs
+npm install
 gulp serve
 ```
 You should be able to browse a local version of the site at http://localhost:3000
 
 ## Pull Requests
-We use the [Git Flow](https://danielkummer.github.io/git-flow-cheatsheet/) branching model and naming conventions to develop new features, and do releases from this repo. Although not required to contribute, we encourage you to follow these confentions when contributing code and opening pull requests.
+We use the [Git Flow](https://danielkummer.github.io/git-flow-cheatsheet/) branching model and naming conventions to develop new features, and do releases from this repo. Although not required to contribute, we encourage you to follow these conventions when contributing code and opening pull requests.
 
 ### Submitting a pull request
-1. Fork the main `rivet-docs-source` repository and then clone your fork locally. Follow [these instructions on syncing your local fork](https://help.github.com/articles/fork-a-repo/#keep-your-fork-synced). Set your new `upstream` remote to point to https://github.iu.edu/UITS/rivet-docs-source.git.
+1. Fork the main `rivet-docs` repository and then clone your fork locally. Follow [these instructions on syncing your local fork](https://help.github.com/articles/fork-a-repo/#keep-your-fork-synced). Set your new `upstream` remote to point to https://github.com/indiana-university/rivet-docs.git.
 2. Create a new feature branch off of `develop` (Ideally using [Git Flow](https://danielkummer.github.io/git-flow-cheatsheet/)) with the prefix `feature/your-feature` e.g. `feature/modal`.
 3. Commit your changes. Be sure to keep your commits narrow in scope and avoid committing changes not related to your feature.
 4. Locally merge any upstream changes into your feature branch: `git pull upstream develop`.
@@ -53,14 +53,3 @@ gulp serve
 ```
 
 To watch and build files without running a server, you can run `gulp watch`. To package up the `public/` folder for distribution, run `gulp build:prod`.
-
-## Automatic deployments
-[Bamboo](https://apps-test.iu.edu/bamboo-snd/browse/UXO-RVT) will run Hugo and move the generated files to either webtest or webserve depending on pushing to develop or master
-
-### URLs
-
-`master` and `develop` branches are deployed automatically using Bamboo and Docker to generate the Hugo site. The following branches deploy to the following URLs:
-
-`master`: https://rivet.iu.edu
-
-`develop`: https://rivet.webtest.iu.edu

--- a/assets/js/components/search.vue
+++ b/assets/js/components/search.vue
@@ -76,7 +76,7 @@
     <div class="rvtd-search__results-found">Found {{results.length}} {{results.length|pluralizeResult}} for <strong>{{activeQuery}}</strong></div>
 
     <div class="rvtd-search__results-footer rvt-m-top-sm">
-      <p>Is something missing? <a :href="'https://github.iu.edu/UITS/rivet-docs-source/issues/new?title='+activeQuery">Open an issue</a> on GitHub (requires an IU account).</p>
+      <p>Is something missing? <a :href="'https://github.com/indiana-university/rivet-docs/issues/new?title='+activeQuery">Open an issue</a> on GitHub (requires an IU account).</p>
     </div>
   </div>
   <div v-if="activeQuery!='' && results.length==0" class="rvtd-search__results rvtd-search__results--none">
@@ -84,7 +84,7 @@
       Your search for <strong class="rvtd-search__no-results-term">{{activeQuery}}</strong> returned no results.
     </div>
     <div class="rvtd-search__results-footer">
-      <p>Is something missing? <a :href="'https://github.iu.edu/UITS/rivet-docs-source/issues/new?title='+activeQuery">Open an issue</a> on GitHub (requires an IU account).</p>
+      <p>Is something missing? <a :href="'https://github.com/indiana-university/rivet-docs/issues/new?title='+activeQuery">Open an issue</a> on GitHub (requires an IU account).</p>
     </div>
   </div>
 </div>

--- a/config.yml
+++ b/config.yml
@@ -14,8 +14,8 @@ params:
   tagline: "Software Design System"
   googleAnalytics: "UA-100560495-3"
   devGoogleAnalytics: "UA-100560495-4"
-  githubRepo: "https://github.iu.edu/UITS/rivet-source"
-  downloadLink: "https://github.iu.edu/UITS/rivet/archive/v1.2.0.zip"
+  githubRepo: "https://github.com/indiana-university/rivet-source"
+  downloadLink: "https://github.com/indiana-university/rivet-source/releases/download/v1.2.0/rivet.zip"
   axureKit: "https://github.iu.edu/UITS/rivet/releases/download/v1.0.0/rivet-axure-1.0.rp"
   description: "Use Rivet to create UITS software that is accessible, usable, and consistent."
   resourceLinks:

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -38,5 +38,5 @@ sections:
     teaser: "A design system is always evolving, and we welcome collaboration with designers and developers to make Rivet even better. Proposals for content or design changes can be submitted as Github issues, then reviewed based on usability, flexibility, accessibility, visual design, and content."
     slug: "how-do-we-develop-it"
     ctaText: "See our backlog"
-    ctaLink: "https://github.iu.edu/UITS/rivet-source/projects/2"
+    ctaLink: "https://github.com/indiana-university/rivet-source/projects/1"
 ---

--- a/content/blog/contributing-to-rivet.md
+++ b/content/blog/contributing-to-rivet.md
@@ -6,23 +6,18 @@ aliases:
     - "/learn/contributing-to-rivet/"
 ---
 ## Github issues
-We’ll be using Github issues to keep track of new component submissions, bugs, design feedback, and any other suggestions related to the design system. To help us understand the kind of contribution you want to make, we ask that you first [submit a Github issue on github.iu.edu](https://github.iu.edu/UITS/rivet-source/issues).
+We’ll be using Github issues to keep track of new component submissions, bugs, design feedback, and any other suggestions related to the design system. To help us understand the kind of contribution you want to make, we ask that you first [submit a Github](https://github.com/indiana-university/rivet-source/issues).
 
-{{< button url="https://github.iu.edu/UITS/rivet-source/issues" >}}Create an issue{{< /button >}}
+{{< button url="https://github.com/indiana-university/rivet-source/issues" >}}Create an issue{{< /button >}}
 
 ## Guidelines
 Here are a few guidelines to follow when creating a new issue:
 
-1. Go to the Rivet source repository on [github.iu.edu](https://github.iu.edu/UITS/rivet-source/issues).
-2. Login with your IU username and passphrase. Don't worry if you've never logged into github.iu.edu before—anyone with a CAS username and passphrase can login and use the service.
-3. Click the "New Issue" button.
-4. Fill out the provided issue template to the best of your ability. If you are submitting a design concept for a new or existing component please attach a screenshot, a link to an Axure mockup, or feel free to link to example HTML/CSS/JavaScript (a link to a pen on Codepen would be great!). We’re looking for anything that will demonstrate your concept here. Don’t worry if it’s unstyled or lacks visual design.
-5. After you have filled out the issue template click the Submit new issue button to create your new issue.
-6. Once the issue is created it will move on to the review process.
-
-## Github Resources
-
-If you need more info, [this Knowledge Base article](https://kb.iu.edu/d/bagk) explains IU's Github Enterprise service in a little more detail and has some handy links to Git and GitHub documentation.
+1. Go to the Rivet source repository on [GitHub](https://github.com/indiana-university/rivet-source/issues).
+2. Click the "New Issue" button.
+3. Fill out the provided issue template to the best of your ability. If you are submitting a design concept for a new or existing component please attach a screenshot, a link to an Axure mockup, or feel free to link to example HTML/CSS/JavaScript (a link to a pen on Codepen would be great!). We’re looking for anything that will demonstrate your concept here. Don’t worry if it’s unstyled or lacks visual design.
+4. After you have filled out the issue template click the Submit new issue button to create your new issue.
+5. Once the issue is created it will move on to the review process.
 
 ## Review process
 Creating an issue is just a way to start a conversation that is visible to the whole team. Anyone should feel free to create a new issue, but before a new submission moves on to a formal review process we’ll ask that it include Each one include:

--- a/content/blog/integrating-rivet.md
+++ b/content/blog/integrating-rivet.md
@@ -247,7 +247,7 @@ Just to recap, here's the code for our final React component:
 {{< /code >}}
 
 ## Example
-You can have a look at the alert component we just created on Codepen. Do you have any ideas on how to improve it or make it more flexible? <a href="mailto:uxo@iu.edu?subject=Rivet React components">Let us know</a> or <a href="https://github.iu.edu/UITS/rivet-source/issues/new">open an issue on Rivet</a>!
+You can have a look at the alert component we just created on Codepen. Do you have any ideas on how to improve it or make it more flexible? <a href="mailto:uxo@iu.edu?subject=Rivet React components">Let us know</a> or <a href="https://github.com/indiana-university/rivet-source/issues/new">open an issue on Rivet</a>!
 
 <p data-height="300" data-theme-id="13463" data-slug-hash="rYBEXJ" data-default-tab="js,result" data-user="levimcg" data-embed-version="2" data-pen-title="Rivet React alert" class="codepen">See the Pen <a href="https://codepen.io/levimcg/pen/rYBEXJ/">Rivet React alert</a> by Levi McGranahan (<a href="https://codepen.io/levimcg">@levimcg</a>) on <a href="https://codepen.io">CodePen</a>.</p>
 <script async src="https://production-assets.codepen.io/assets/embed/ei.js"></script>

--- a/content/blog/open-sourcing-rivet.md
+++ b/content/blog/open-sourcing-rivet.md
@@ -16,7 +16,7 @@ The UX Office will be moving the Rivet source code from IU's Enterprise GitHub i
 Closed issues and pull requests can’t be transferred to GitHub.com—however, you’ll still be able to view them on the archived Rivet repos on github.iu.edu.
 
 <div class="rvt-alert rvt-alert--info rvt-m-bottom-md rvt-m-top-sm">
-    <p class="rvt-alert__message">Make sure to <strong>unwatch</strong> the <code>rivet-source</code> and <code>rivet-docs-source</code> repos before the migration date. Otherwise, you may get a lot of notifications in your inbox.</p>
+    <p class="rvt-alert__message">Make sure to <strong>unwatch</strong> the <code>rivet-source</code> and <code>rivet-docs</code> repos before the migration date. Otherwise, you may get a lot of notifications in your inbox.</p>
 </div>
 
 ## Getting started with GitHub.com
@@ -27,7 +27,7 @@ If you would like to contribute to Rivet's development, you'll need to create a 
 1. Enter the email address you’d like associated with your account, such as your IU email address
 1. Click “Sign up for GitHub”
 
-Once you have an account, you’ll be able to create and comment on issues, fork repositories, and open pull requests on any of the Rivet repositories. 
+Once you have an account, you’ll be able to create and comment on issues, fork repositories, and open pull requests on any of the Rivet repositories.
 
 If you were watching any of the Rivet repositories or any issues, you’ll need to visit the newly-migrated Rivet repos and re-watch them.
 

--- a/content/blog/release-0.5.0.md
+++ b/content/blog/release-0.5.0.md
@@ -48,6 +48,6 @@ As we mentioned above this will be the **last release before we move to 1.0.0**.
 ## Feedback & Questions
 We'd appreciate any feedback you have and would be happy to answer any questions. The best way to submit feedback is by creating an issue on Github:
 
-https://github.iu.edu/UITS/rivet-source/issues
+https://github.com/indiana-university/rivet-source/issues
 
 Thanks!

--- a/content/blog/release-1-1-0.md
+++ b/content/blog/release-1-1-0.md
@@ -11,7 +11,7 @@ Rivet 1.1.0 is now available! This release fixes a lot of JavaScript-related iss
 
 <div class="rvt-alert rvt-alert--info rvt-m-bottom-md rvt-m-top-sm">
     <h3 class="rvt-alert__title" id="warning-alert-title">Changes in 1.1.0</h3>
-    <p class="rvt-alert__message">This release makes significant changes to the underlying structure of Rivet's JavaScript. If you run into any problems updating to 1.1.0, please <a href="https://github.iu.edu/UITS/rivet-source/issues">file an issue on GitHub</a>.</p>
+    <p class="rvt-alert__message">This release makes significant changes to the underlying structure of Rivet's JavaScript. If you run into any problems updating to 1.1.0, please <a href="https://github.com/indiana-university/rivet-source/issues">file an issue on GitHub</a>.</p>
 </div>
 
 ## JavaScript updates

--- a/content/blog/release-1.0.0.md
+++ b/content/blog/release-1.0.0.md
@@ -14,7 +14,7 @@ The [last pre-release of Rivet]({{< ref "blog/release-0.5.0.md" >}}) was the mos
 
 <div class="rvt-alert rvt-alert--info rvt-m-bottom-md rvt-m-top-sm">
     <h3 class="rvt-alert__title" id="warning-alert-title">Changes in 1.0.0</h3>
-    <p class="rvt-alert__message">The updates we've made since the last release (0.5.0) were all additive and shouldn't be breaking changes. If you do run into any problems updating, <a href="https://github.iu.edu/UITS/rivet-source/issues">please open an issue on Github.iu</a>.</p>
+    <p class="rvt-alert__message">The updates we've made since the last release (0.5.0) were all additive and shouldn't be breaking changes. If you do run into any problems updating, <a href="https://github.com/indiana-university/rivet-source/issues">please open an issue on Github.iu</a>.</p>
 </div>
 
 ## 1.0.0 Additions
@@ -33,6 +33,6 @@ This quarter we'll be working on more documentation and training around using Ri
 
 We would appreciate any feedback you have and be happy to answer any questions. The best way to submit feedback is by creating an issue on Github.IU, or email uxo@iu.edu:
 
-https://github.iu.edu/UITS/rivet-source/issues
+https://github.com/indiana-university/rivet-source/issues
 
 Thanks!

--- a/content/blog/rivet-add-ons.md
+++ b/content/blog/rivet-add-ons.md
@@ -20,11 +20,11 @@ We've created Add-ons for a few reasons:
 ## Using Rivet Add-ons
 We've added a new section to the Rivet website where you can find a list of available Add-ons, along with instructions on how to use Add-ons in your project.
 
-Each Add-on page contains: 
+Each Add-on page contains:
 
 - Links to download the code needed to use the Add-on
 - A link to the GitHub repository that hosts the Add-on's source code
-- A demo page showing a working example of the Add-on 
+- A demo page showing a working example of the Add-on
 
 ## Creating issues for Rivet Add-ons
 If you have a question, want to report a bug, or have a feature request, create a GitHub issue on the Add-on repository.
@@ -43,6 +43,6 @@ If you've created a custom Rivet component you think might be useful to other te
 If you need help developing your Add-on, the Rivet core team is happy to help with visual design, front-end development, and accesibility.
 
 [components-docs]: ../../components
-[rivet-source]: https://github.iu.edu/UITS/rivet-source/issues
+[rivet-source]: https://github.com/indiana-university/rivet-source/issues
 [add-ons-page]: ../../add-ons
 [boilerplate]: https://github.com/indiana-university/rivet-add-on-boilerplate

--- a/content/blog/rivet-in-2019.md
+++ b/content/blog/rivet-in-2019.md
@@ -25,7 +25,7 @@ In addition to fixes and improvements, here’s a quick summary of the major upd
 ## Other highlights
 Here are a few links to show what we’ve been working on the last few months. These should also give you an idea about what’s on the horizon for future Rivet releases.
 
-- [Rivet backlog project board](https://github.iu.edu/UITS/rivet-source/projects/2)
+- [Rivet backlog project board](https://github.com/indiana-university/rivet-source/projects/1)
     - This is the project board we currently use to track to dos, in-progress tasks, and completed features, fixes, etc. **NOTE: This link will change when we move to github.com**.
 - Rivet datepicker
     - **This is not ready for production yet**, but will be released soon as a Rivet Add-on

--- a/content/components/_index.md
+++ b/content/components/_index.md
@@ -19,7 +19,7 @@ The Rivet components documentation contains examples, code snippets, and guidanc
 ## Download Rivet
 You can download a ZIP file that contains the compiled and minified CSS and JavaScript, images, and a starter HTML file.
 
-{{< button url="https://github.iu.edu/UITS/rivet-source/releases/download/v1.2.0/rivet.zip" variant="secondary" analytics-action="download" analytics-category="click">}}
+{{< button url="https://github.com/indiana-university/rivet-source/releases/download/v1.2.0/rivet.zip" variant="secondary" analytics-action="download" analytics-category="click">}}
     <span class="rvt-m-right-xs">Download Rivet</span>
     <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
         <g fill="currentColor">

--- a/content/components/information/contributing.md
+++ b/content/components/information/contributing.md
@@ -4,23 +4,18 @@ description: "If you have created a component you think would be useful to other
 excludeFromStatus: true
 ---
 ## Github issues
-We’ll be using Github issues to keep track of new component submissions, bugs, design feedback, and any other suggestions related to the design system. To help us understand the kind of contribution you want to make, we ask that you first [submit a Github issue on github.iu.edu](https://github.iu.edu/UITS/rivet-source/issues).
+We’ll be using Github issues to keep track of new component submissions, bugs, design feedback, and any other suggestions related to the design system. To help us understand the kind of contribution you want to make, we ask that you first [submit an issue on GitHub](https://github.com/indiana-university/rivet-source/issues).
 
-{{< button url="https://github.iu.edu/UITS/rivet-source/issues" >}}Create an issue{{< /button >}}
+{{< button url="https://github.com/indiana-university/rivet-source/issues" >}}Create an issue{{< /button >}}
 
 ## Guidelines
 Here are a few guidelines to follow when creating a new issue:
 
-1. Go to the Rivet source repository on [github.iu.edu](https://github.iu.edu/UITS/rivet-source/issues).
-2. Login with your IU username and passphrase. Don't worry if you've never logged into github.iu.edu before—anyone with a CAS username and passphrase can login and use the service.
-3. Click the "New Issue" button.
-4. Fill out the provided issue template to the best of your ability. If you are submitting a design concept for a new or existing component please attach a screenshot, a link to an Axure mockup, or feel free to link to example HTML/CSS/JavaScript (a link to a pen on Codepen would be great!). We’re looking for anything that will demonstrate your concept here. Don’t worry if it’s unstyled or lacks visual design.
-5. After you have filled out the issue template click the Submit new issue button to create your new issue.
-6. Once the issue is created it will move on to the review process.
-
-## Github Resources
-
-If you need more info, [this Knowledge Base article](https://kb.iu.edu/d/bagk) explains IU's Github Enterprise service in a little more detail and has some handy links to Git and GitHub documentation.
+1. Go to the Rivet source repository on [GitHub](https://github.com/indiana-university/rivet-source/issues).
+2. Click the "New Issue" button.
+3. Fill out the provided issue template to the best of your ability. If you are submitting a design concept for a new or existing component please attach a screenshot, a link to an Axure mockup, or feel free to link to example HTML/CSS/JavaScript (a link to a pen on Codepen would be great!). We’re looking for anything that will demonstrate your concept here. Don’t worry if it’s unstyled or lacks visual design.
+4. After you have filled out the issue template click the Submit new issue button to create your new issue.
+5. Once the issue is created it will move on to the review process.
 
 ## Review process
 Creating an issue is just a way to start a conversation that is visible to the whole team. Anyone should feel free to create a new issue, but before a new submission moves on to a formal review process we’ll ask that each one includes:
@@ -34,7 +29,6 @@ Creating an issue is just a way to start a conversation that is visible to the w
 - context (screenshots, links) if you have a specific use case for a proposed solution
 
 ### Collaboration
-
 If you are a developer and want help with your submission from a designer, make sure to mention that when creating your issue and someone from the review team will help pair you up with a designer. Same goes for designers that want help from a developer.
 
 ### Content changes


### PR DESCRIPTION
This PR updates old links to github.iu where appropriate. Some of them link to old archived PRs so will need to remain. And the changelog URL will need to stay in place until we move the release notes over.