### PR TITLE
Release/1.9.1

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -28,14 +28,14 @@ sections:
         title: "Developer Advocate"
         avatar: "https://ux.iu.edu/img/scott-thumbnail.jpg"
       -
-        name: "Front-end Developer"
-        title: 'Vacant position | <a class="rvt-text-bold" href="/jobs/front-end-developer">Apply now</a>'
-        avatar: "../img/rvtd-avatar-placeholder.jpg"
+        name: "Rachel O'Connor"
+        title: "Front-end Developer"
+        avatar: "https://ux.iu.edu/img/rachel-thumbnail.jpg"
   -
     image: "../img/about-dev-process.png"
     title: "What is our development process?"
     teaser: "A design system is always evolving, and we welcome collaboration with designers and developers to make Rivet even better. Proposals for content or design changes can be submitted as Github issues, then reviewed based on usability, flexibility, accessibility, visual design, and content."
     slug: "how-do-we-develop-it"
     ctaText: "See our backlog"
-    ctaLink: "https://github.com/indiana-university/rivet-source/projects/1"
+    ctaLink: "https://github.com/orgs/indiana-university/projects/2"
 ---

--- a/content/blog/rivet-in-2019.md
+++ b/content/blog/rivet-in-2019.md
@@ -25,7 +25,7 @@ In addition to fixes and improvements, here’s a quick summary of the major upd
 ## Other highlights
 Here are a few links to show what we’ve been working on the last few months. These should also give you an idea about what’s on the horizon for future Rivet releases.
 
-- [Rivet backlog project board](https://github.com/indiana-university/rivet-source/projects/1)
+- [Rivet backlog project board](https://github.com/orgs/indiana-university/projects/2)
     - This is the project board we currently use to track to dos, in-progress tasks, and completed features, fixes, etc. **NOTE: This link will change when we move to github.com**.
 - Rivet datepicker
     - **This is not ready for production yet**, but will be released soon as a Rivet Add-on

--- a/content/components/forms/text-input.md
+++ b/content/components/forms/text-input.md
@@ -91,7 +91,7 @@ Rivet does not make any assumptions about whether you’re using server- or clie
             </g>
         </svg>
     </span>
-    <span class="rvt-inline-alert__message" role="alert" id="first-name-message">
+    <span class="rvt-inline-alert__message" id="first-name-message">
         <strong>First name</strong> is valid!
     </span>
 </div>
@@ -107,7 +107,7 @@ Rivet does not make any assumptions about whether you’re using server- or clie
             </g>
         </svg>
     </span>
-    <span class="rvt-inline-alert__message" role="alert" id="password-message">
+    <span class="rvt-inline-alert__message" id="password-message">
         Your <strong>Password</strong> is weak.
     </span>
 </div>
@@ -123,7 +123,7 @@ Rivet does not make any assumptions about whether you’re using server- or clie
             </g>
         </svg>
     </span>
-    <span class="rvt-inline-alert__message" role="alert" id="username-message">
+    <span class="rvt-inline-alert__message" id="username-message">
         The <strong>Username</strong> you entered is taken.
     </span>
 </div>
@@ -140,7 +140,7 @@ Rivet does not make any assumptions about whether you’re using server- or clie
             </g>
         </svg>
     </span>
-    <span class="rvt-inline-alert__message" role="alert" id="description-message">
+    <span class="rvt-inline-alert__message" id="description-message">
         The
         <strong>Description</strong> tells users more about this stuff.
     </span>

--- a/content/components/layout/grid.md
+++ b/content/components/layout/grid.md
@@ -5,11 +5,16 @@ status: "Ready"
 ---
 
 ## About the grid
-The Rivet grid is a mobile-first grid system based on [flexbox](https://www.w3.org/TR/css-flexbox-1/). It is based on five screen sizes and uses CSS classes to specify how many columns the grid should have at each of these screen sizes.
+The Rivet grid is a mobile-first grid system built with [flexbox](https://www.w3.org/TR/css-flexbox-1/). It is based on five screen sizes and uses CSS classes to specify how many columns the grid should have at each of the breakpoints listed in the following documentation. 
 
-<h3>The grid and spacing utilities <span class="rvt-badge rvt-badge--warning">Note</span></h3>
+### Grid breakpoints
+See the [_Setting column widths_](#setting-column-widths) section for instructions on how to apply column widths at the different breakpoint sizes.
 
-Please note that using any horizontal (`rvt-m-left-*`, `rvt-p-left-*`, `rvt-m-right-*`, and `rvt-p-right-*`) [spacing utilities]({{< relref "spacing.md" >}}) on the `.rvt-grid__item-*`s will throw off the grid gutters and maybe break your layout.
+{{< breakpoints >}}{{< /breakpoints >}}
+
+{{< alert variant="warning" title="Grid and spacing utilities" >}}
+Please note that using any horizontal (`rvt-m-left-*`, `rvt-p-left-*`, `rvt-m-right-*`, and `rvt-p-right-*`) [spacing utilities](../spacing) on the `.rvt-grid__item-*`s will throw off the grid gutters and maybe break your layout.
+{{< /alert >}}
 
 ## The container
 The `.rvt-container` is the basic layout unit in Rivet. A basic `.rvt-container` element is fluid by default. It will take up the full width of the viewport with a default of `1.5rem` of padding on the left and right sides.

--- a/content/components/layout/spacing.md
+++ b/content/components/layout/spacing.md
@@ -8,90 +8,25 @@ status: "Ready"
 To maintain consistent spacing between components and to help create a sense of vertical rhythm, we have created a spacing system based on `.5rem` (8px) unit. Margins and padding can be applied using a set of CSS utility classes to add or remove margin and padding from any element.
 
 ### Spacing examples
-<table class="rvt-m-top-lg">
-    <caption class="sr-only">Rivet spacing utilities</caption>
-    <thead>
-        <th>CSS suffix</th>
-        <th>rem</th>
-        <th>px</th>
-        <th>Example</th>
-    </thead>
-    <tbody>
-        <tr>
-            <td><code>-xxs</code></td>
-            <td>.25rem</td>
-            <td>4px</td>
-            <td>
-                <div class="rvtd-space-example p-all-xxs">
-                    <p class="rvtd-space-example-inner m-all-remove p-all-xs">Extra extra small</p>
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td><code>-xs</code></td>
-            <td>.5rem</td>
-            <td>8px</td>
-            <td>
-                <div class="rvtd-space-example p-all-xs">
-                    <p class="rvtd-space-example-inner m-all-remove p-all-xs">Extra small</p>
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td><code>-sm</code></td>
-            <td>1rem</td>
-            <td>16px</td>
-            <td>
-                <div class="rvtd-space-example p-all-sm">
-                    <p class="rvtd-space-example-inner m-all-remove p-all-xs">Small</p>
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td><code>-md</code></td>
-            <td>1.5rem</td>
-            <td>24px</td>
-            <td>
-                <div class="rvtd-space-example p-all-md">
-                    <p class="rvtd-space-example-inner m-all-remove p-all-xs">Medium</p>
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td><code>-lg</code></td>
-            <td>2rem</td>
-            <td>32px</td>
-            <td>
-                <div class="rvtd-space-example p-all-lg">
-                    <p class="rvtd-space-example-inner m-all-remove p-all-xs">Large</p>
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td><code>-xl</code></td>
-            <td>2.5rem</td>
-            <td>40px</td>
-            <td>
-                <div class="rvtd-space-example p-all-xl">
-                    <p class="rvtd-space-example-inner m-all-remove p-all-xs">Extra large</p>
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td><code>-xxl</code></td>
-            <td>3rem</td>
-            <td>48px</td>
-            <td>
-                <div class="rvtd-space-example p-all-xxl">
-                    <p class="rvtd-space-example-inner m-all-remove p-all-xs">Extra extra large</p>
-                </div>
-            </td>
-        </tr>
-    </tbody>
-</table>
+{{< spacing >}}{{< /spacing >}}
+
+## Spacing Sass variables
+If you are using [Rivet's Sass](https://github.com/indiana-university/rivet-source/blob/develop/src/sass/core/_variables.scss#L325) files you can directly access any spacing unit by its variable name. The spacing unit variables follow the same naming conventions as all of Rivet's spacing utility classes.
+
+{{< code >}}// Global spacing units
+
+$spacing-unit: .5rem;        // 8px
+
+$xxs: $spacing-unit/2;       // 4px
+$xs: $spacing-unit;          // 8px
+$sm: $spacing-unit * 2;      // 16px Base
+$md: $spacing-unit * 3;      // 24px
+$lg: $spacing-unit * 4;      // 32px
+$xl: $spacing-unit * 5;      // 40px
+$xxl: $spacing-unit * 8;     // 64px
+{{</ code >}}
 
 ## Implementation
-
 The CSS classes for the spacing system use the following conventions:
 
 - `rvt` = namespace
@@ -109,7 +44,6 @@ The CSS classes for the spacing system use the following conventions:
 So the class `.rvt-m-top-sm` would add 16px/1rem of margin on all screen sizes to the top of the element it was applied to.
 
 ### Responsive spacing
-
 Each spacing utility class also comes with a set of modifiers that allow you to adjust spacing at different screen sizes. Take the following `div`
 
 {{< code >}}<div class="rvt-p-bottom-sm rvt-p-bottom-lg-lg-up">
@@ -120,7 +54,6 @@ Each spacing utility class also comes with a set of modifiers that allow you to 
 With these spacing classes applied, it would have 16px/1rem of bottom padding at all screen sizes and 32px/2rem of bottom padding on large screens (1080px wide) and up.
 
 ### Spacing modifiers
-
 All spacing utilities described above have the following responsive modifiers available to them:
 
 - `-sm-up` - screens **480–740px** and wider
@@ -129,8 +62,12 @@ All spacing utilities described above have the following responsive modifiers av
 - `-xl-up` - screens **1260–1400px** and wider
 - `-xxl-up` - screens **1400px** and wider
 
+{{< alert variant="info" title="Rivet breakpoints" >}}
+See the documentation about Rivet's global breakpoints in [the grid documentation](../grid/#grid-breakpoints).
+{{< /alert >}}
+
 ### All spacing
 Using the size conventions above you could apply the class `.rvt-p-all-xl` to add an Extra large amount (40px/2.5rem) to both the top and bottom of an element.
 
 ### No spacing
-If you want to get crazy and remove all margin or padding from and element you could use the class `.rvt-m-all-remove`, or `.rvt-p-all-remove`.
+If you want to remove all margin or padding from and element you could use the class `.rvt-m-all-remove`, or `.rvt-p-all-remove`.

--- a/content/components/layout/typography.md
+++ b/content/components/layout/typography.md
@@ -11,8 +11,6 @@ Typography is the core component of any interface. Rivet uses a defined [Major S
 ## Type scale examples
 {{< typescale data="tokens" >}}{{< /typescale >}}
 
-
-
 ## Type scale Sass variables
 If you are using [Rivet's Sass][type-variables] files you can directly access any value in the Rivet type scale by it's variable name. All of the type scale values are stored in a [Sass map][sass-maps] that we use to iterate over and produce the type [scale utility classes](./#type-scale-examples) including the [aliases listed in the following documentation](./#type-scale-aliases).
 

--- a/content/components/layout/typography.md
+++ b/content/components/layout/typography.md
@@ -9,95 +9,9 @@ status: "Ready"
 Typography is the core component of any interface. Rivet uses a defined [Major Second](http://type-scale.com/?size=16&scale=1.125&text=A%20Visual%20Type%20Scale&webfont=Libre+Baskerville&font-family=%27Libre%20Baskerville%27,%20serif&font-weight=400&font-family-headers=&font-weight-headers=inherit&background-color=white&font-color=#333) type scale that has been rounded to the nearest whole pixel value. Using sizes from this scale will help create a hierarchy and consistency throughout your application.
 
 ## Type scale examples
-<table class="rvt-m-top-lg">
-  <caption class="rvt-sr-only">Rivet type scale</caption>
-  <thead>
-    <th>CSS lass</th>
-    <th>rem</th>
-    <th>px</th>
-    <th>Actual size</th>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>.rvt-ts-12, .rvt-ts-xxs</code></td>
-      <td>.75rem</td>
-      <td>12px</td>
-      <td class="rvt-ts-12">Fulfilling the promise</td>
-    </tr>
-    <tr>
-      <td><code>.rvt-ts-14, .rvt-ts-xs</code></td>
-      <td>.875rem</td>
-      <td>14px</td>
-      <td class="rvt-ts-14">Fulfilling the promise</td>
-    </tr>
-    <tr>
-      <td><code>.rvt-ts-base, .rvt-ts-16</code></td>
-      <td>1rem</td>
-      <td>16px</td>
-      <td class="rvt-ts-base">Fulfilling the promise</td>
-    </tr>
-    <tr>
-      <td><code>.rvt-ts-18</code></td>
-      <td>1.125rem</td>
-      <td>18px</td>
-      <td class="rvt-ts-18">Fulfilling the promise</td>
-    </tr>
-    <tr>
-      <td><code>.rvt-ts-20, .rvt-ts-sm</code></td>
-      <td>1.25rem</td>
-      <td>20px</td>
-      <td class="rvt-ts-20">Fulfilling the promise</td>
-    </tr>
-    <tr>
-      <td><code>.rvt-ts-23</code></td>
-      <td>1.4375rem</td>
-      <td>23px</td>
-      <td class="rvt-ts-23">Fulfilling the promise</td>
-    </tr>
-    <tr>
-      <td><code>.rvt-ts-26, .rvt-ts-md</code></td>
-      <td>1.625rem</td>
-      <td>26px</td>
-      <td class="rvt-ts-26">Fulfilling the promise</td>
-    </tr>
-    <tr>
-      <td><code>.rvt-ts-29</code></td>
-      <td>1.8125rem</td>
-      <td>29px</td>
-      <td class="rvt-ts-29">Fulfilling the promise</td>
-    </tr>
-    <tr>
-      <td><code>.rvt-ts-32, .rvt-ts-lg</code></td>
-      <td>2rem</td>
-      <td>32px</td>
-      <td class="rvt-ts-32">Fulfilling the promise</td>
-    </tr>
-    <tr>
-      <td><code>.rvt-ts-36</code></td>
-      <td>2.25rem</td>
-      <td>36px</td>
-      <td class="rvt-ts-36">Fulfilling the promise</td>
-    </tr>
-    <tr>
-      <td><code>.rvt-ts-41, .rvt-ts-xl</code></td>
-      <td>2.5625rem</td>
-      <td>41px</td>
-      <td class="rvt-ts-41">Fulfilling the promise</td>
-    </tr>
-    <tr>
-      <td><code>.rvt-ts-46</code></td>
-      <td>2.875rem</td>
-      <td>46px</td>
-      <td class="rvt-ts-46">Fulfilling the promise</td>
-    </tr>
-    <tr>
-      <td><code>.rvt-ts-52, .rvt-ts-xxl</code></td>
-      <td>3.25rem</td>
-      <td>52px</td>
-      <td class="rvt-ts-52">Fulfilling the promise</td>
-    </tr>
-  </tbody>
-</table>
+{{< typescale data="tokens" >}}{{< /typescale >}}
+
+
 
 ## Type scale Sass variables
 If you are using [Rivet's Sass][type-variables] files you can directly access any value in the Rivet type scale by it's variable name. All of the type scale values are stored in a [Sass map][sass-maps] that we use to iterate over and produce the type [scale utility classes](./#type-scale-examples) including the [aliases listed in the following documentation](./#type-scale-aliases).

--- a/content/components/layout/typography.md
+++ b/content/components/layout/typography.md
@@ -100,7 +100,7 @@ Typography is the core component of any interface. Rivet uses a defined [Major S
 </table>
 
 ## Type scale Sass variables
-If you are using [Rivet's Sass source][type-variables] files you can directly access any value in the Rivet type scale by it's variable name. All of the type scale values are stored in a [Sass map][sass-maps] that we use to iterate over and produce the type [scale utility classes](./#type-scale-examples) including the [aliases listed in the following documentation](./#type-scale-aliases).
+If you are using [Rivet's Sass][type-variables] files you can directly access any value in the Rivet type scale by it's variable name. All of the type scale values are stored in a [Sass map][sass-maps] that we use to iterate over and produce the type [scale utility classes](./#type-scale-examples) including the [aliases listed in the following documentation](./#type-scale-aliases).
 
 {{< code >}}// Main Sass map
 
@@ -129,7 +129,7 @@ $type-sizes: (
 )
 {{< /code >}}
 
-From the main Sass map we then create short variables for each type size as well as a set of memorable alias variables e.g. `-xxs`, `-xs`, `-sm`, `-md`, `-lg`, `-xl`, `-xxl`.
+From the main Sass map we then create short-cut variables for each type size as well as a set of memorable alias variables e.g. `-xxs`, `-xs`, `-sm`, `-md`, `-lg`, `-xl`, `-xxl`.
 
 {{< code >}}// Type Size variables
 
@@ -202,9 +202,9 @@ To make it easier to keep type sizes to a minimum we have create a few CSS utili
 ### Responsive type scale
 Each type scale helper class comes with a set of modifiers that allow you to adjust font-size at different screen sizes. Here's an example.
 
-{{< code >}}<h1 class="rvt-ts-20 rvt-ts-32-md-up">Profile page</h1>
+{{< example lang="html" >}}<h1 class="rvt-ts-20 rvt-ts-32-md-up">Profile page</h1>
 <p class="rvt-ts-14">The profile page is where you can select your personal settings.</p>
-{{< /code >}}
+{{< /example >}}
 
 Given the markup above, the `h1` would have a font size of 1.25rem/20px on all screens small and larger, and 2.25rem/36px on medium screens(740px wide) and larger.
 

--- a/content/components/layout/typography.md
+++ b/content/components/layout/typography.md
@@ -133,30 +133,30 @@ From the main Sass map we then create short-cut variables for each type size as 
 
 {{< code >}}// Type Size variables
 
-$ts-12: map-get($type-sizes, 12) !default;
-$ts-14: map-get($type-sizes, 14) !default;
-$ts-16: map-get($type-sizes, 16) !default;
-$ts-18: map-get($type-sizes, 18) !default;
-$ts-20: map-get($type-sizes, 20) !default;
-$ts-23: map-get($type-sizes, 23) !default;
-$ts-26: map-get($type-sizes, 26) !default;
-$ts-29: map-get($type-sizes, 29) !default;
-$ts-32: map-get($type-sizes, 32) !default;
-$ts-36: map-get($type-sizes, 36) !default;
-$ts-41: map-get($type-sizes, 41) !default;
-$ts-46: map-get($type-sizes, 46) !default;
-$ts-52: map-get($type-sizes, 52) !default;
+$ts-12: map-get($type-sizes, 12);
+$ts-14: map-get($type-sizes, 14);
+$ts-16: map-get($type-sizes, 16);
+$ts-18: map-get($type-sizes, 18);
+$ts-20: map-get($type-sizes, 20);
+$ts-23: map-get($type-sizes, 23);
+$ts-26: map-get($type-sizes, 26);
+$ts-29: map-get($type-sizes, 29);
+$ts-32: map-get($type-sizes, 32);
+$ts-36: map-get($type-sizes, 36);
+$ts-41: map-get($type-sizes, 41);
+$ts-46: map-get($type-sizes, 46);
+$ts-52: map-get($type-sizes, 52);
 
 // Type scale aliases
 
-$ts-xxs: $ts-12 !default;
-$ts-xs: $ts-14 !default;
-$ts-base: $ts-16 !default;
-$ts-sm: $ts-20 !default;
-$ts-md: $ts-26 !default;
-$ts-lg: $ts-32 !default;
-$ts-xl: $ts-41 !default;
-$ts-xxl: $ts-52 !default;
+$ts-xxs: $ts-12;
+$ts-xs: $ts-14;
+$ts-base: $ts-16;
+$ts-sm: $ts-20;
+$ts-md: $ts-26;
+$ts-lg: $ts-32;
+$ts-xl: $ts-41;
+$ts-xxl: $ts-52;
 {{< /code >}}
 
 ### Using typography Sass variables

--- a/content/components/layout/typography.md
+++ b/content/components/layout/typography.md
@@ -9,7 +9,7 @@ status: "Ready"
 Typography is the core component of any interface. Rivet uses a defined [Major Second](http://type-scale.com/?size=16&scale=1.125&text=A%20Visual%20Type%20Scale&webfont=Libre+Baskerville&font-family=%27Libre%20Baskerville%27,%20serif&font-weight=400&font-family-headers=&font-weight-headers=inherit&background-color=white&font-color=#333) type scale that has been rounded to the nearest whole pixel value. Using sizes from this scale will help create a hierarchy and consistency throughout your application.
 
 ## Type scale examples
-{{< typescale data="tokens" >}}{{< /typescale >}}
+{{< typescale >}}{{< /typescale >}}
 
 ## Type scale Sass variables
 If you are using [Rivet's Sass][type-variables] files you can directly access any value in the Rivet type scale by its variable name. All of the type scale values are stored in a [Sass map][sass-maps] that we use to produce the type [scale utility classes](./#type-scale-examples), including the [aliases listed in the following documentation](./#type-scale-aliases).
@@ -127,6 +127,10 @@ The responsive type scale CSS classes use the following conventions:
 - `-lg-up` - screens **1080–1260px** and wider
 - `-xl-up` - screens **1260–1400px** and wider
 - `-xxl-up` - screens **1400px** and wider
+
+{{< alert variant="info" title="Rivet breakpoints" >}}
+See the documentation about Rivet's global breakpoints in [the grid documentation](../grid/#grid-breakpoints).
+{{< /alert >}}
 
 [type-variables]: https://github.com/indiana-university/rivet-source/blob/develop/src/sass/core/_variables.scss
 [sass-maps]: http://sass-lang.com/documentation/file.SASS_REFERENCE.html#maps

--- a/content/components/layout/typography.md
+++ b/content/components/layout/typography.md
@@ -9,96 +9,164 @@ status: "Ready"
 Typography is the core component of any interface. Rivet uses a defined [Major Second](http://type-scale.com/?size=16&scale=1.125&text=A%20Visual%20Type%20Scale&webfont=Libre+Baskerville&font-family=%27Libre%20Baskerville%27,%20serif&font-weight=400&font-family-headers=&font-weight-headers=inherit&background-color=white&font-color=#333) type scale that has been rounded to the nearest whole pixel value. Using sizes from this scale will help create a hierarchy and consistency throughout your application.
 
 ## Type scale examples
-
 <table class="rvt-m-top-lg">
-    <caption class="rvt-sr-only">Rivet type scale</caption>
-    <thead>
-        <th>Helper Class</th>
-        <th>rem</th>
-        <th>px</th>
-        <th>Actual size</th>
-    </thead>
-    <tbody>
-        <tr>
-            <td><code>.rvt-ts-12, .rvt-ts-xxs</code></td>
-            <td>.75rem</td>
-            <td>12px</td>
-            <td class="rvt-ts-12">Fulfilling the promise</td>
-        </tr>
-        <tr>
-            <td><code>.rvt-ts-14, .rvt-ts-xs</code></td>
-            <td>.875rem</td>
-            <td>14px</td>
-            <td class="rvt-ts-14">Fulfilling the promise</td>
-        </tr>
-        <tr>
-            <td><code>.rvt-ts-base, .rvt-ts-16</code></td>
-            <td>1rem</td>
-            <td>16px</td>
-            <td class="rvt-ts-base">Fulfilling the promise</td>
-        </tr>
-        <tr>
-            <td><code>.rvt-ts-18</code></td>
-            <td>1.125rem</td>
-            <td>18px</td>
-            <td class="rvt-ts-18">Fulfilling the promise</td>
-        </tr>
-        <tr>
-            <td><code>.rvt-ts-20, .rvt-ts-sm</code></td>
-            <td>1.25rem</td>
-            <td>20px</td>
-            <td class="rvt-ts-20">Fulfilling the promise</td>
-        </tr>
-        <tr>
-            <td><code>.rvt-ts-23</code></td>
-            <td>1.4375rem</td>
-            <td>23px</td>
-            <td class="rvt-ts-23">Fulfilling the promise</td>
-        </tr>
-        <tr>
-            <td><code>.rvt-ts-26, .rvt-ts-md</code></td>
-            <td>1.625rem</td>
-            <td>26px</td>
-            <td class="rvt-ts-26">Fulfilling the promise</td>
-        </tr>
-        <tr>
-            <td><code>.rvt-ts-29</code></td>
-            <td>1.8125rem</td>
-            <td>29px</td>
-            <td class="rvt-ts-29">Fulfilling the promise</td>
-        </tr>
-        <tr>
-            <td><code>.rvt-ts-32, .rvt-ts-lg</code></td>
-            <td>2rem</td>
-            <td>32px</td>
-            <td class="rvt-ts-32">Fulfilling the promise</td>
-        </tr>
-        <tr>
-            <td><code>.rvt-ts-36</code></td>
-            <td>2.25rem</td>
-            <td>36px</td>
-            <td class="rvt-ts-36">Fulfilling the promise</td>
-        </tr>
-        <tr>
-            <td><code>.rvt-ts-41, .rvt-ts-xl</code></td>
-            <td>2.5625rem</td>
-            <td>41px</td>
-            <td class="rvt-ts-41">Fulfilling the promise</td>
-        </tr>
-        <tr>
-            <td><code>.rvt-ts-46</code></td>
-            <td>2.875rem</td>
-            <td>46px</td>
-            <td class="rvt-ts-46">Fulfilling the promise</td>
-        </tr>
-        <tr>
-            <td><code>.rvt-ts-52, .rvt-ts-xxl</code></td>
-            <td>3.25rem</td>
-            <td>52px</td>
-            <td class="rvt-ts-52">Fulfilling the promise</td>
-        </tr>
-    </tbody>
+  <caption class="rvt-sr-only">Rivet type scale</caption>
+  <thead>
+    <th>CSS lass</th>
+    <th>rem</th>
+    <th>px</th>
+    <th>Actual size</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>.rvt-ts-12, .rvt-ts-xxs</code></td>
+      <td>.75rem</td>
+      <td>12px</td>
+      <td class="rvt-ts-12">Fulfilling the promise</td>
+    </tr>
+    <tr>
+      <td><code>.rvt-ts-14, .rvt-ts-xs</code></td>
+      <td>.875rem</td>
+      <td>14px</td>
+      <td class="rvt-ts-14">Fulfilling the promise</td>
+    </tr>
+    <tr>
+      <td><code>.rvt-ts-base, .rvt-ts-16</code></td>
+      <td>1rem</td>
+      <td>16px</td>
+      <td class="rvt-ts-base">Fulfilling the promise</td>
+    </tr>
+    <tr>
+      <td><code>.rvt-ts-18</code></td>
+      <td>1.125rem</td>
+      <td>18px</td>
+      <td class="rvt-ts-18">Fulfilling the promise</td>
+    </tr>
+    <tr>
+      <td><code>.rvt-ts-20, .rvt-ts-sm</code></td>
+      <td>1.25rem</td>
+      <td>20px</td>
+      <td class="rvt-ts-20">Fulfilling the promise</td>
+    </tr>
+    <tr>
+      <td><code>.rvt-ts-23</code></td>
+      <td>1.4375rem</td>
+      <td>23px</td>
+      <td class="rvt-ts-23">Fulfilling the promise</td>
+    </tr>
+    <tr>
+      <td><code>.rvt-ts-26, .rvt-ts-md</code></td>
+      <td>1.625rem</td>
+      <td>26px</td>
+      <td class="rvt-ts-26">Fulfilling the promise</td>
+    </tr>
+    <tr>
+      <td><code>.rvt-ts-29</code></td>
+      <td>1.8125rem</td>
+      <td>29px</td>
+      <td class="rvt-ts-29">Fulfilling the promise</td>
+    </tr>
+    <tr>
+      <td><code>.rvt-ts-32, .rvt-ts-lg</code></td>
+      <td>2rem</td>
+      <td>32px</td>
+      <td class="rvt-ts-32">Fulfilling the promise</td>
+    </tr>
+    <tr>
+      <td><code>.rvt-ts-36</code></td>
+      <td>2.25rem</td>
+      <td>36px</td>
+      <td class="rvt-ts-36">Fulfilling the promise</td>
+    </tr>
+    <tr>
+      <td><code>.rvt-ts-41, .rvt-ts-xl</code></td>
+      <td>2.5625rem</td>
+      <td>41px</td>
+      <td class="rvt-ts-41">Fulfilling the promise</td>
+    </tr>
+    <tr>
+      <td><code>.rvt-ts-46</code></td>
+      <td>2.875rem</td>
+      <td>46px</td>
+      <td class="rvt-ts-46">Fulfilling the promise</td>
+    </tr>
+    <tr>
+      <td><code>.rvt-ts-52, .rvt-ts-xxl</code></td>
+      <td>3.25rem</td>
+      <td>52px</td>
+      <td class="rvt-ts-52">Fulfilling the promise</td>
+    </tr>
+  </tbody>
 </table>
+
+## Type scale Sass variables
+If you are using [Rivet's Sass source][type-variables] files you can directly access any value in the Rivet type scale by it's variable name. All of the type scale values are stored in a [Sass map][sass-maps] that we use to iterate over and produce the type [scale utility classes](./#type-scale-examples) including the [aliases listed in the following documentation](./#type-scale-aliases).
+
+{{< code >}}// Main Sass map
+
+$type-sizes: (
+  12: .75rem,
+  xxs: .75rem,
+  14: .875rem,
+  xs: .875rem,
+  16: 1rem,
+  base: 1rem,
+  18: 1.125rem,
+  20: 1.25rem,
+  sm: 1.25rem,
+  23: 1.4375rem,
+  26: 1.625rem,
+  md: 1.625rem,
+  29: 1.8125rem,
+  32: 2rem,
+  lg: 2rem,
+  36: 2.25rem,
+  41: 2.5625rem,
+  xl: 2.5625rem,
+  46: 2.875rem,
+  52: 3.25rem,
+  xxl: 3.25rem,
+)
+{{< /code >}}
+
+From the main Sass map we then create short variables for each type size as well as a set of memorable alias variables e.g. `-xxs`, `-xs`, `-sm`, `-md`, `-lg`, `-xl`, `-xxl`.
+
+{{< code >}}// Type Size variables
+
+$ts-12: map-get($type-sizes, 12) !default;
+$ts-14: map-get($type-sizes, 14) !default;
+$ts-16: map-get($type-sizes, 16) !default;
+$ts-18: map-get($type-sizes, 18) !default;
+$ts-20: map-get($type-sizes, 20) !default;
+$ts-23: map-get($type-sizes, 23) !default;
+$ts-26: map-get($type-sizes, 26) !default;
+$ts-29: map-get($type-sizes, 29) !default;
+$ts-32: map-get($type-sizes, 32) !default;
+$ts-36: map-get($type-sizes, 36) !default;
+$ts-41: map-get($type-sizes, 41) !default;
+$ts-46: map-get($type-sizes, 46) !default;
+$ts-52: map-get($type-sizes, 52) !default;
+
+// Type scale aliases
+
+$ts-xxs: $ts-12 !default;
+$ts-xs: $ts-14 !default;
+$ts-base: $ts-16 !default;
+$ts-sm: $ts-20 !default;
+$ts-md: $ts-26 !default;
+$ts-lg: $ts-32 !default;
+$ts-xl: $ts-41 !default;
+$ts-xxl: $ts-52 !default;
+{{< /code >}}
+
+### Using typography Sass variables
+Here's and example of how you could use the type scale Sass variables when customizing Rivet:
+
+{{< code >}}.custom-heading {
+  font-size: $ts-26; // Font size = 26px/1.625rem
+  font-weight: 700;
+}
+{{< /code >}}
 
 ## Typeface
 Benton Sans is an official IU font and is available for free to all IU schools, departments, offices, and affiliated units.
@@ -147,3 +215,6 @@ The responsive type scale CSS classes use the following conventions:
 - `-lg-up` - screens **1080–1260px** and wider
 - `-xl-up` - screens **1260–1400px** and wider
 - `-xxl-up` - screens **1400px** and wider
+
+[type-variables]: https://github.com/indiana-university/rivet-source/blob/develop/src/sass/core/_variables.scss
+[sass-maps]: http://sass-lang.com/documentation/file.SASS_REFERENCE.html#maps

--- a/content/components/layout/typography.md
+++ b/content/components/layout/typography.md
@@ -12,7 +12,7 @@ Typography is the core component of any interface. Rivet uses a defined [Major S
 {{< typescale data="tokens" >}}{{< /typescale >}}
 
 ## Type scale Sass variables
-If you are using [Rivet's Sass][type-variables] files you can directly access any value in the Rivet type scale by it's variable name. All of the type scale values are stored in a [Sass map][sass-maps] that we use to iterate over and produce the type [scale utility classes](./#type-scale-examples) including the [aliases listed in the following documentation](./#type-scale-aliases).
+If you are using [Rivet's Sass][type-variables] files you can directly access any value in the Rivet type scale by its variable name. All of the type scale values are stored in a [Sass map][sass-maps] that we use to produce the type [scale utility classes](./#type-scale-examples), including the [aliases listed in the following documentation](./#type-scale-aliases).
 
 {{< code >}}// Main Sass map
 
@@ -41,7 +41,7 @@ $type-sizes: (
 )
 {{< /code >}}
 
-From the main Sass map we then create short-cut variables for each type size as well as a set of memorable alias variables e.g. `-xxs`, `-xs`, `-sm`, `-md`, `-lg`, `-xl`, `-xxl`.
+From the main Sass map we then create shortcut variables for each type size, as well as a set of memorable alias variables e.g. `-xxs`, `-xs`, `-sm`, `-md`, `-lg`, `-xl`, `-xxl`.
 
 {{< code >}}// Type Size variables
 
@@ -72,7 +72,7 @@ $ts-xxl: $ts-52;
 {{< /code >}}
 
 ### Using typography Sass variables
-Here's and example of how you could use the type scale Sass variables when customizing Rivet:
+Here's an example of how you might use the type scale Sass variables when customizing Rivet:
 
 {{< code >}}.custom-heading {
   font-size: $ts-26; // Font size = 26px/1.625rem

--- a/content/components/overlays/alerts.md
+++ b/content/components/overlays/alerts.md
@@ -152,7 +152,7 @@ Inline alerts in Rivet should be used for form validation situations where [the 
 {{< /example >}}
 
 {{< alert variant="info" title="More form validation tips" >}}
-For more information on techniques for better from validation UX, [see this list of form validation tips](../../forms/text-input/#form-validation-tips).
+For more information on techniques for better form validation UX, [see this list of form validation tips](../../forms/text-input/#form-validation-tips).
 {{< /alert >}}
 
 When using a standalone inline alert with a group of inputs, make sure to add the `aria-describedby` attribute to **each input** (in this case radio buttons) that is invalid. The `aria-describedy` by value should correspond to a matching `id` attribute on the `.rvt-inline-alert__message` element.

--- a/content/components/overlays/alerts.md
+++ b/content/components/overlays/alerts.md
@@ -103,7 +103,7 @@ Inline alerts in Rivet should be used for form validation situations where [the 
             </g>
         </svg>
     </span>
-    <span class="rvt-inline-alert__message" role="alert" id="radio-list-message">
+    <span class="rvt-inline-alert__message" id="radio-list-message">
         This field is required to continue.
     </span>
 </div>
@@ -117,7 +117,7 @@ Inline alerts in Rivet should be used for form validation situations where [the 
             </g>
         </svg>
     </span>
-    <span class="rvt-inline-alert__message" role="alert" id="radio-list-message">
+    <span class="rvt-inline-alert__message" id="radio-list-message">
         This field is required to continue.
     </span>
 </div>
@@ -131,7 +131,7 @@ Inline alerts in Rivet should be used for form validation situations where [the 
             </g>
         </svg>
     </span>
-    <span class="rvt-inline-alert__message" role="alert" id="radio-list-message">
+    <span class="rvt-inline-alert__message" id="radio-list-message">
         This field is required to continue.
     </span>
 </div>
@@ -145,18 +145,15 @@ Inline alerts in Rivet should be used for form validation situations where [the 
             </g>
         </svg>
     </span>
-    <span class="rvt-inline-alert__message" role="alert" id="radio-list-message">
+    <span class="rvt-inline-alert__message" id="radio-list-message">
         This field is required to continue.
     </span>
 </div>
 {{< /example >}}
 
-<div class="rvt-alert rvt-alert--info rvt-m-bottom-md rvt-m-top-xl">
-    <h2 class="rvt-alert__title">More form validation tips</h2>
-    <p class="rvt-alert__message">
-        For more information on techniques for better from validation UX, <a href="../../forms/text-input/#form-validation-tips">see this list of form validation tips</a>.
-    </p>
-</div>
+{{< alert variant="info" title="More form validation tips" >}}
+For more information on techniques for better from validation UX, [see this list of form validation tips](../../forms/text-input/#form-validation-tips).
+{{< /alert >}}
 
 When using a standalone inline alert with a group of inputs, make sure to add the `aria-describedby` attribute to **each input** (in this case radio buttons) that is invalid. The `aria-describedy` by value should correspond to a matching `id` attribute on the `.rvt-inline-alert__message` element.
 
@@ -191,7 +188,7 @@ When using a standalone inline alert with a group of inputs, make sure to add th
                     </g>
                 </svg>
             </span>
-            <span class="rvt-inline-alert__message" role="alert" id="radio-list-message">
+            <span class="rvt-inline-alert__message" id="radio-list-message">
                 This field is required to continue.
             </span>
         </div>

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -48,5 +48,57 @@
       "size": 52,
       "alias": "xxl"
     }
+  ],
+  "spacing": [
+    {
+      "size": 4,
+      "alias": "xxs"
+    },
+    {
+      "size": 8,
+      "alias": "xs"
+    },
+    {
+      "size": 16,
+      "alias": "sm"
+    },
+    {
+      "size": 24,
+      "alias": "md"
+    },
+    {
+      "size": 32,
+      "alias": "lg"
+    },
+    {
+      "size": 40,
+      "alias": "xl"
+    },
+    {
+      "size": 48,
+      "alias": "xxl"
+    }
+  ],
+  "breakpoints": [
+    {
+      "size": 480,
+      "alias": "sm"
+    },
+    {
+      "size": 740,
+      "alias": "md"
+    },
+    {
+      "size": 1080,
+      "alias": "lg"
+    },
+    {
+      "size": 1260,
+      "alias": "xl"
+    },
+    {
+      "size": 1400,
+      "alias": "xxl"
+    }
   ]
 }

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -1,0 +1,52 @@
+{
+  "baseFontSize": 16,
+  "typography": [
+    {
+      "size": 12,
+      "alias": "xxs"
+    },
+    {
+      "size": 14,
+      "alias": "xs"
+    },
+    {
+      "size": 16,
+      "alias": "base"
+    },
+    {
+      "size": 18
+    },
+    {
+      "size": 20,
+      "alias": "sm"
+    },
+    {
+      "size": 23
+    },
+    {
+      "size": 26,
+      "alias": "md"
+    },
+    {
+      "size": 29
+    },
+    {
+      "size": 32,
+      "alias": "lg"
+    },
+    {
+      "size": 36
+    },
+    {
+      "size": 41,
+      "alias": "xl"
+    },
+    {
+      "size": 46
+    },
+    {
+      "size": 52,
+      "alias": "xxl"
+    }
+  ]
+}

--- a/layouts/shortcodes/breakpoints.html
+++ b/layouts/shortcodes/breakpoints.html
@@ -15,23 +15,19 @@
 */}}
 {{ $TokensData := $.Site.Data.tokens }}
 
-<table class="rvt-m-top-lg rvt-table-compact">
-  <caption class="rvt-sr-only">Rivet type scale</caption>
+<table class="rvt-m-top-lg rvt-table-stripes rvt-table-compact">
+  <caption class="rvt-sr-only">Rivet breakpoints</caption>
   <thead>
-    <th>CSS class</th>
     <th>Sass variable</th>
-    <th>rem</th>
-    <th>px</th>
-    <th>Actual size</th>
+    <th>Viewport width (px)</th>
+    <th>Viewport width (rem)</th>
   </thead>
   <tbody>
-    {{- range $.Site.Data.tokens.typography -}}
+    {{- range $.Site.Data.tokens.breakpoints -}}
       <tr>
-        <td width="150"><code>.rvt-ts-{{ .size }}{{ if .alias }},<br> .rvt-ts-{{ .alias }}{{ end }}</code></td>
-        <td><code>$ts-{{ .size }}</code></td>
-        <td>{{ trim (div (.size) ($TokensData.baseFontSize)) "0" }}rem</td>
+        <td><code>$breakpoint-{{ .alias }}</code></td>
         <td>{{ .size }}px</td>
-        <td class="rvt-ts-{{ .size }}">Fulfilling the promise</td>
+        <td>{{ trim (div (.size) ($TokensData.baseFontSize)) "0" }}rem</td>
       </tr>
     {{- end -}}
   </tbody>

--- a/layouts/shortcodes/spacing.html
+++ b/layouts/shortcodes/spacing.html
@@ -16,22 +16,26 @@
 {{ $TokensData := $.Site.Data.tokens }}
 
 <table class="rvt-m-top-lg rvt-table-compact">
-  <caption class="rvt-sr-only">Rivet type scale</caption>
+  <caption class="rvt-sr-only">Rivet spacing units</caption>
   <thead>
-    <th>CSS class</th>
+    <th>CSS suffix</th>
     <th>Sass variable</th>
     <th>rem</th>
     <th>px</th>
-    <th>Actual size</th>
+    <th>Example</th>
   </thead>
   <tbody>
-    {{- range $.Site.Data.tokens.typography -}}
+    {{- range $.Site.Data.tokens.spacing -}}
       <tr>
-        <td width="150"><code>.rvt-ts-{{ .size }}{{ if .alias }},<br> .rvt-ts-{{ .alias }}{{ end }}</code></td>
-        <td><code>$ts-{{ .size }}</code></td>
+        <td><code>-{{ .alias }}</code></td>
+        <td><code>${{ .alias }}</code></td>
         <td>{{ trim (div (.size) ($TokensData.baseFontSize)) "0" }}rem</td>
         <td>{{ .size }}px</td>
-        <td class="rvt-ts-{{ .size }}">Fulfilling the promise</td>
+        <td>
+          <div class="rvtd-space-example p-all-{{ .alias }}">
+            <p class="rvtd-space-example-inner m-all-remove p-all-xs">{{ .alias }}</p>
+          </div>
+        </td>
       </tr>
     {{- end -}}
   </tbody>

--- a/layouts/shortcodes/typescale.html
+++ b/layouts/shortcodes/typescale.html
@@ -1,0 +1,36 @@
+{{/*
+  This shortcode is used to generate the type scale table based on the
+  main "tokens.json" data file: ../../data/tokens.json
+*/}}
+
+{{/*
+  You have to call .Inner for shortcodes to work even if you're not putting
+  content inside the tags.
+  */}}
+{{ .Inner }}
+
+{{/*
+  Stores a reference to the main "tokens" object, so we can get at other
+  values inside the loop below.
+*/}}
+{{ $TokensData := $.Site.Data.tokens }}
+
+<table class="rvt-m-top-lg rvt-table-compact">
+  <caption class="rvt-sr-only">Rivet type scale</caption>
+  <thead>
+    <th>CSS class</th>
+    <th>rem</th>
+    <th>px</th>
+    <th>Actual size</th>
+  </thead>
+  <tbody>
+    {{- range $.Site.Data.tokens.typography -}}
+      <tr>
+        <td><code>.rvt-ts-{{ .size }}{{ if .alias }}, .rvt-ts-{{ .alias }}{{ end }}</code></td>
+        <td>{{ trim (div (.size) ($TokensData.baseFontSize)) "0" }}rem</td>
+        <td>{{ .size }}px</td>
+        <td class="rvt-ts-{{ .size }}">Fulfilling the promise</td>
+      </tr>
+    {{- end -}}
+  </tbody>
+</table>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivet-docs",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Rivet design system documentation website",
   "main": "index.html",
   "author": "Indiana University",


### PR DESCRIPTION
This PR adds new documentation for typography, spacing, and breakpoint Sass variables as well as a few other fixes and updates.

- Added documentation
- Updated links to [new unified project board](https://github.com/orgs/indiana-university/projects/2)
- Updated Rivet team section
- Replaced hard coded type scale and spacing demos with new shortcodes

@illusivesunrae Once you've had a chance to look this over, I'll merge and push a new tag so we can get these updates on the live docs site.