### PR TITLE
Added type property to non-submittable buttons and created alert

### DIFF
--- a/content/components/forms/buttons-segmented.md
+++ b/content/components/forms/buttons-segmented.md
@@ -8,18 +8,18 @@ weight: 2
 
 ## Segmented button examples
 {{< example lang="html" >}}<div class="rvt-button-segmented" role="group" aria-label="Primary controls">
-    <button class="rvt-button">Primary one</button>
-    <button class="rvt-button">Primary two</button>
-    <button class="rvt-button">Primary three</button>
+    <button type="button" class="rvt-button">Primary one</button>
+    <button type="button" class="rvt-button">Primary two</button>
+    <button type="button" class="rvt-button">Primary three</button>
 </div>
 {{< /example >}}
 
 ### Secondary modifier
 The segmented buttons can be used with any of Rivet's button modifiers.
 {{< example lang="html" >}}<div class="rvt-button-segmented" role="group" aria-label="Secondary controls">
-    <button class="rvt-button rvt-button--secondary">Secondary one</button>
-    <button class="rvt-button rvt-button--secondary">Secondary two</button>
-    <button class="rvt-button rvt-button--secondary">Secondary three</button>
+    <button type="button" class="rvt-button rvt-button--secondary">Secondary one</button>
+    <button type="button" class="rvt-button rvt-button--secondary">Secondary two</button>
+    <button type="button" class="rvt-button rvt-button--secondary">Secondary three</button>
 </div>
 {{< /example >}}
 
@@ -37,9 +37,9 @@ As an alternative, you could also use an `aria-labelledby` attribute. Its value 
 Adding the `.rvt-button-segmented--fitted` modifier to the segmented buttons' `<div>` container will make the buttons fill the entire width of their parent container.
 
 {{< example lang="html" >}}<div class="rvt-button-segmented rvt-button-segmented--fitted" role="group" aria-label="Fitted group">
-    <button class="rvt-button rvt-button--secondary">Left</button>
-    <button class="rvt-button rvt-button--secondary">Middle</button>
-    <button class="rvt-button rvt-button--secondary">Right</button>
+    <button type="button" class="rvt-button rvt-button--secondary">Left</button>
+    <button type="button" class="rvt-button rvt-button--secondary">Middle</button>
+    <button type="button" class="rvt-button rvt-button--secondary">Right</button>
 </div>
 {{< /example >}}
 
@@ -52,22 +52,22 @@ It _is_ possible to use segmented buttons with anchor tags if the situation call
 You can use the segmented button along with Rivet's dropdown component to create more complex controls like in the example below. Here we are also using some [padding utility classes]({{< ref "components/layout/spacing.md" >}}) to slightly decrease the width of the secondary action dropdown toggle.
 
 {{< example lang="html" >}}<div class="rvt-button-segmented" role="group" aria-label="Dropdown group">
-    <button class="rvt-button">Primary action</button>
+    <button type="button" class="rvt-button">Primary action</button>
     <div class="rvt-dropdown">
-        <button class="rvt-button rvt-p-right-xs rvt-p-left-xs" data-dropdown-toggle="segmented-example">
+        <button type="button" class="rvt-button rvt-p-right-xs rvt-p-left-xs" data-dropdown-toggle="segmented-example">
             <span class="rvt-sr-only">Toggle options menu</span>
             <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
                 <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
             </svg>
         </button>
         <div class="rvt-dropdown__menu" id="segmented-example" role="menu" aria-hidden="true">
-            <button role="menuitemradio">Notify all</button>
-            <button role="menuitemradio" aria-checked="true">Notify admins</button>
-            <button role="menuitemradio">Notify contributors</button>
+            <button type="button" role="menuitemradio">Notify all</button>
+            <button type="button" role="menuitemradio" aria-checked="true">Notify admins</button>
+            <button type="button" role="menuitemradio">Notify contributors</button>
             <div class="rvt-dropdown__menu-heading" aria-hidden="true">Personal settings</div>
             <div role="group" aria-label="Personal settings">
-                <button role="menuitem">Profile Settings</button>
-                <button role="menuitem">Logout</button>
+                <button type="button" role="menuitem">Profile Settings</button>
+                <button type="button" role="menuitem">Logout</button>
             </div>
         </div>
     </div>

--- a/content/components/forms/buttons.md
+++ b/content/components/forms/buttons.md
@@ -23,6 +23,10 @@ status: "Ready"
 </div>
 {{< /example >}}
 
+{{< alert variant="warning" title="Button types" >}}
+Be aware that when using buttons, unless they have the `type="button"` attribute, they will automatically submit nearby forms on the page.
+{{< /alert >}}
+
 ### Small buttons
 You can create smaller buttons by adding the `.rvt-button--small` modifier class. The small button modifier can be used together with the other button modifier classes to make any variation of small buttons.
 
@@ -83,13 +87,13 @@ When you use icons inside buttons, you should still include button text to descr
 See the example below using the `.rvt-sr-only` utility class to visually hide the button text.
 
 {{< example lang="html" >}}<div class="rvt-button-group">
-    <button class="rvt-button">
+    <button type="button" class="rvt-button">
         <span class="rvt-m-right-xs">Add item</span>
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
             <path fill="currentColor" d="M14,7H9V2A1,1,0,0,0,7,2V7H2A1,1,0,0,0,2,9H7v5a1,1,0,0,0,2,0V9h5a1,1,0,0,0,0-2Z"/>
         </svg>
     </button>
-    <button class="rvt-button">
+    <button type="button" class="rvt-button">
         <span class="rvt-m-right-xs">Copy</span>
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
             <g fill="currentColor">
@@ -98,7 +102,7 @@ See the example below using the `.rvt-sr-only` utility class to visually hide th
             </g>
         </svg>
     </button>
-    <button class="rvt-button rvt-button--danger">
+    <button type="button" class="rvt-button rvt-button--danger">
         <span class="rvt-m-right-xs">Delete</span>
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
             <g fill="currentColor">
@@ -107,7 +111,7 @@ See the example below using the `.rvt-sr-only` utility class to visually hide th
             </g>
         </svg>
     </button>
-    <button class="rvt-button rvt-button--secondary">
+    <button type="button" class="rvt-button rvt-button--secondary">
         <span class="rvt-sr-only">Edit entry</span>
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
             <path fill="currentColor" d="M14.62,4.19,11.74,1.34a1.1,1.1,0,0,0-1.55,0L0,11.62,0,16l4.45,0L14.64,5.73A1.1,1.1,0,0,0,14.62,4.19ZM3.62,14H2V12.44l6-6L9.58,8ZM11,6.57,9.4,5,11,3.4,12.57,5Z"/>
@@ -123,16 +127,16 @@ The `.rvt-button rvt-button--*` classes are meant to be used on the `<button>` e
 When you need to display a group of buttons you can wrap them in a `div` with the class `.rvt-button-group` applied to it. The `.rvt-button-group` class will add an equal amount of margin to the right side of every button in the group except the last one.
 
 {{< example lang="html" >}}<div class="rvt-button-group">
-    <button class="rvt-button">Ok</button>
-    <button class="rvt-button rvt-button--secondary">Cancel</button>
+    <button type="button" class="rvt-button">Ok</button>
+    <button type="button" class="rvt-button rvt-button--secondary">Cancel</button>
 </div>
 {{< /example >}}
 
 If you need to right align your buttons, you can add the `.rvt-button-group--right` modifier class to the `.rvt-button-group` div.
 
 {{< example lang="html" >}}<div class="rvt-button-group rvt-button-group--right">
-    <button class="rvt-button">Ok</button>
-    <button class="rvt-button rvt-button--secondary">Cancel</button>
+    <button type="button" class="rvt-button">Ok</button>
+    <button type="button" class="rvt-button rvt-button--secondary">Cancel</button>
 </div>
 {{< /example >}}
 

--- a/content/components/forms/buttons.md
+++ b/content/components/forms/buttons.md
@@ -24,7 +24,7 @@ status: "Ready"
 {{< /example >}}
 
 {{< alert variant="warning" title="Button types" >}}
-Be aware that when using buttons, unless they have the `type="button"` attribute, they will automatically submit nearby forms on the page.
+Be aware that buttons will automatically submit nearby forms on the page unless they have the `type="button"` attribute.
 {{< /alert >}}
 
 ### Small buttons

--- a/content/components/forms/input-group.md
+++ b/content/components/forms/input-group.md
@@ -18,16 +18,16 @@ status: "Ready"
 <div class="rvt-input-group rvt-m-top-xl">
     <div class="rvt-input-group__prepend">
         <div class="rvt-dropdown">
-            <button class="rvt-button rvt-p-right-xs rvt-p-left-xs" data-dropdown-toggle="segmented-prepend-example">
+            <button type="button" class="rvt-button rvt-p-right-xs rvt-p-left-xs" data-dropdown-toggle="segmented-prepend-example">
                 <span class="rvt-m-right-xs">Filter</span>
                 <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
                     <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
                 </svg>
             </button>
             <div class="rvt-dropdown__menu" role="menu" aria-hidden="true" id="segmented-prepend-example">
-                <button role="menuitemradio">My Stuff</button>
-                <button role="menuitemradio" aria-checked="true">All stuff</button>
-                <button role="menuitemradio">Archives</button>
+                <button type="button" role="menuitemradio">My Stuff</button>
+                <button type="button" role="menuitemradio" aria-checked="true">All stuff</button>
+                <button type="button" role="menuitemradio">Archives</button>
             </div>
         </div>
     </div>

--- a/content/components/information/contributing.md
+++ b/content/components/information/contributing.md
@@ -6,7 +6,7 @@ excludeFromStatus: true
 ## Github issues
 We’ll be using Github issues to keep track of new component submissions, bugs, design feedback, and any other suggestions related to the design system. To help us understand the kind of contribution you want to make, we ask that you first [submit an issue on GitHub](https://github.com/indiana-university/rivet-source/issues/new/choose).
 
-{{<button  type="button" url="https://github.com/indiana-university/rivet-source/issues/new/choose" >}}Create an issue{{< /button >}}
+{{<button url="https://github.com/indiana-university/rivet-source/issues/new/choose" >}}Create an issue{{< /button >}}
 
 ## Guidelines
 Here are a few guidelines to follow when creating a new issue:

--- a/content/components/information/contributing.md
+++ b/content/components/information/contributing.md
@@ -6,7 +6,7 @@ excludeFromStatus: true
 ## Github issues
 We’ll be using Github issues to keep track of new component submissions, bugs, design feedback, and any other suggestions related to the design system. To help us understand the kind of contribution you want to make, we ask that you first [submit an issue on GitHub](https://github.com/indiana-university/rivet-source/issues/new/choose).
 
-{{< button url="https://github.com/indiana-university/rivet-source/issues/new/choose" >}}Create an issue{{< /button >}}
+{{<button  type="button" url="https://github.com/indiana-university/rivet-source/issues/new/choose" >}}Create an issue{{< /button >}}
 
 ## Guidelines
 Here are a few guidelines to follow when creating a new issue:

--- a/content/components/navigation/dropdown.md
+++ b/content/components/navigation/dropdown.md
@@ -50,6 +50,7 @@ events:
 ## Dropdown example
 {{< example lang="html" >}}<div class="rvt-dropdown">
     <button
+         type="button"
         class="rvt-button"
         data-dropdown-toggle="dropdown-navigation"
         aria-haspopup="true"
@@ -117,6 +118,7 @@ To align the dropdown menu with the right side of the dropdown button, add the `
 
 {{< example lang="html" >}}<div class="rvt-dropdown">
     <button
+        type="button"
         class="rvt-button rvt-button--secondary"
         data-dropdown-toggle="dropdown-right"
         aria-haspopup="true"
@@ -154,20 +156,20 @@ We’ve also included a couple of extra layout elements here for when you may ne
 The following example shows how to implement these additional dropdown elements.
 
 {{< example lang="html" >}}<div class="rvt-dropdown">
-    <button class="rvt-button" data-dropdown-toggle="dropdown-1" aria-haspopup="true" aria-expanded="false">
+    <button type="button" class="rvt-button" data-dropdown-toggle="dropdown-1" aria-haspopup="true" aria-expanded="false">
         <span>Application menu</span>
         <svg aria-hidden="true" class="rvt-m-left-xs" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
             <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
         </svg>
     </button>
     <div class="rvt-dropdown__menu" id="dropdown-1" role="menu" aria-hidden="true">
-        <button role="menuitemradio">Notify all</button>
-        <button role="menuitemradio" aria-checked="true">Notify admins</button>
-        <button role="menuitemradio">Notify contributors</button>
+        <button type="button" role="menuitemradio">Notify all</button>
+        <button type="button" role="menuitemradio" aria-checked="true">Notify admins</button>
+        <button type="button" role="menuitemradio">Notify contributors</button>
         <div class="rvt-dropdown__menu-heading" aria-hidden="true">Personal settings</div>
         <div role="group" aria-label="Personal settings">
-            <button role="menuitem">Profile Settings</button>
-            <button role="menuitem">Logout</button>
+            <button type="button" role="menuitem">Profile Settings</button>
+            <button type="button" role="menuitem">Logout</button>
         </div>
     </div>
 </div>

--- a/content/components/navigation/header.md
+++ b/content/components/navigation/header.md
@@ -96,7 +96,7 @@ The inclusion of an avatar and username, or only username are both appropriate c
                 Log out
             </a>
         </div>
-        <button class="rvt-drawer-button" aria-haspopup="true" aria-expanded="false" data-drawer-toggle="mobile-drawer">
+        <button type="button" class="rvt-drawer-button" aria-haspopup="true" aria-expanded="false" data-drawer-toggle="mobile-drawer">
             <span class="sr-only">Toggle menu</span>
             <svg aria-hidden="true" class="rvt-drawer-button-open" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
                 <g fill="currentColor">
@@ -120,7 +120,7 @@ The inclusion of an avatar and username, or only username are both appropriate c
                 </a>
             </div>
         </div>
-        <button class="rvt-drawer__bottom-close">Close nav</button>
+        <button type="button" class="rvt-drawer__bottom-close">Close nav</button>
     </div>
 </header>
 {{< /example >}}
@@ -152,7 +152,7 @@ These lists work best for priority tasks and internal navigation. Consider inclu
                 </li>
                 <li>
                     <div class="rvt-dropdown">
-                        <button class="rvt-dropdown__toggle" data-dropdown-toggle="dropdown-1" aria-haspopup="true" aria-expanded="false">
+                        <button type="button" class="rvt-dropdown__toggle" data-dropdown-toggle="dropdown-1" aria-haspopup="true" aria-expanded="false">
                             <span class="rvt-dropdown__toggle-text">Nav two</span>
                             <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
                                 <title>Dropdown icon</title>
@@ -173,7 +173,7 @@ These lists work best for priority tasks and internal navigation. Consider inclu
                 </li>
                 <li>
                     <div class="rvt-dropdown">
-                        <button class="rvt-dropdown__toggle" data-dropdown-toggle="dropdown-2" aria-haspopup="true" aria-expanded="false">
+                        <button type="button" class="rvt-dropdown__toggle" data-dropdown-toggle="dropdown-2" aria-haspopup="true" aria-expanded="false">
                             <span class="rvt-dropdown__toggle-text">Nav four</span>
                             <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
                                 <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
@@ -192,7 +192,7 @@ These lists work best for priority tasks and internal navigation. Consider inclu
         <!-- ID menu w/ dropdown -->
         <div class="rvt-header-id">
             <div class="rvt-dropdown">
-                <button class="rvt-header-id__profile rvt-header-id__profile--has-dropdown rvt-dropdown__toggle" data-dropdown-toggle="id-dropdown" aria-haspopup="true" aria-expanded="false">
+                <button type="button" class="rvt-header-id__profile rvt-header-id__profile--has-dropdown rvt-dropdown__toggle" data-dropdown-toggle="id-dropdown" aria-haspopup="true" aria-expanded="false">
                     <span class="rvt-header-id__avatar" aria-hidden="true">RS</span>
                     <span class="rvt-header-id__user">rswanson</span>
                     <svg aria-hidden="true" class="rvt-m-left-xs" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
@@ -210,7 +210,7 @@ These lists work best for priority tasks and internal navigation. Consider inclu
             </div>
         </div>
         <!-- Drawer close button - shows on small screens -->
-        <button class="rvt-drawer-button" aria-haspopup="true" aria-expanded="false" data-drawer-toggle="mobile-drawer-2">
+        <button type="button" class="rvt-drawer-button" aria-haspopup="true" aria-expanded="false" data-drawer-toggle="mobile-drawer-2">
             <span class="sr-only">Toggle menu</span>
             <svg aria-hidden="true" class="rvt-drawer-button-open" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
                 <g fill="currentColor">
@@ -236,7 +236,7 @@ These lists work best for priority tasks and internal navigation. Consider inclu
         <nav class="rvt-drawer__nav" role="navigation">
             <ul>
                 <li class="has-children">
-                    <button class="rvt-header-id__profile rvt-header-id__profile--drawer" data-subnav-toggle="subnav-id" aria-haspopup="true" aria-expanded="false">
+                    <button type="button" class="rvt-header-id__profile rvt-header-id__profile--drawer" data-subnav-toggle="subnav-id" aria-haspopup="true" aria-expanded="false">
                         <span class="rvt-header-id__avatar" aria-hidden="true">RS</span>
                         <span class="rvt-header-id__user rvt-header-id__user--has-dropdown">rswanson</span>
                     </button>
@@ -261,7 +261,7 @@ These lists work best for priority tasks and internal navigation. Consider inclu
                     <a href="#">Nav one</a>
                 </li>
                 <li class="has-children">
-                    <button data-subnav-toggle="subnav-1" aria-haspopup="true" aria-expanded="false">Nav two</button>
+                    <button type="button" data-subnav-toggle="subnav-1" aria-haspopup="true" aria-expanded="false">Nav two</button>
                     <div id="subnav-1" role="menu" aria-hidden="true">
                         <ul>
                             <li>
@@ -280,7 +280,7 @@ These lists work best for priority tasks and internal navigation. Consider inclu
                     <a href="#" aria-current="page">Nav three</a>
                 </li>
                 <li class="has-children">
-                    <button data-subnav-toggle="subnav-2" aria-haspopup="true" aria-expanded="false">Nav four</button>
+                    <button type="button" data-subnav-toggle="subnav-2" aria-haspopup="true" aria-expanded="false">Nav four</button>
                     <div id="subnav-2" role="menu" aria-hidden="true">
                         <ul>
                             <li>
@@ -296,7 +296,7 @@ These lists work best for priority tasks and internal navigation. Consider inclu
                     </div>
                 </li>
             </ul>
-            <button class="rvt-drawer__bottom-close">Close nav</button>
+            <button type="button" class="rvt-drawer__bottom-close">Close nav</button>
         </nav>
     </div>
 </header>
@@ -335,7 +335,7 @@ Additionally, any navigation item that will contain sub navigation items needs t
     <nav class="rvt-drawer__nav" role="navigation">
         <ul>
             <li class="has-children">
-                <button class="rvt-header-id__profile rvt-header-id__profile--drawer" data-subnav-toggle="subnav-id" aria-haspopup="true" aria-expanded="false">
+                <button type="button" class="rvt-header-id__profile rvt-header-id__profile--drawer" data-subnav-toggle="subnav-id" aria-haspopup="true" aria-expanded="false">
                     <span class="rvt-header-id__avatar" aria-hidden="true">RS</span>
                     <span class="rvt-header-id__user rvt-header-id__user--has-dropdown">rswanson</span>
                 </button>
@@ -358,7 +358,7 @@ Additionally, any navigation item that will contain sub navigation items needs t
             </li>
             <li><a href="#0">Nav one</a></li>
             <li class="has-children">
-                <button data-subnav-toggle="subnav-1" aria-haspopup="true" aria-expanded="false">Nav two</button>
+                <button type="button" data-subnav-toggle="subnav-1" aria-haspopup="true" aria-expanded="false">Nav two</button>
                 <div id="subnav-1" role="menu" aria-hidden="true">
                     <ul>
                         <li>
@@ -375,7 +375,7 @@ Additionally, any navigation item that will contain sub navigation items needs t
             </li>
             <li><a href="#0">Nav three</a></li>
             <li class="has-children">
-                <button data-subnav-toggle="subnav-2" aria-haspopup="true" aria-expanded="false">Nav four</button>
+                <button type="button" data-subnav-toggle="subnav-2" aria-haspopup="true" aria-expanded="false">Nav four</button>
                 <div id="subnav-2" role="menu" aria-hidden="true">
                     <ul>
                         <li>
@@ -391,7 +391,7 @@ Additionally, any navigation item that will contain sub navigation items needs t
                 </div>
             </li>
         </ul>
-        <button class="rvt-drawer__bottom-close">Close nav</button>
+        <button type="button" class="rvt-drawer__bottom-close">Close nav</button>
     </nav>
 </div>
 {{< /code >}}
@@ -402,7 +402,7 @@ When your application has multiple user-specific functions (e.g. "Account settin
 {{< code >}}<!-- ID menu w/ dropdown -->
 <div class="rvt-header-id">
     <div class="rvt-dropdown">
-        <button class="rvt-header-id__profile rvt-header-id__profile--has-dropdown rvt-dropdown__toggle" data-dropdown-toggle="id-dropdown" aria-haspopup="true" aria-expanded="false">
+        <button type="button" class="rvt-header-id__profile rvt-header-id__profile--has-dropdown rvt-dropdown__toggle" data-dropdown-toggle="id-dropdown" aria-haspopup="true" aria-expanded="false">
             <span class="rvt-header-id__avatar" aria-hidden="true">RS</span>
             <span class="rvt-header-id__user">rswanson</span>
             <svg aria-hidden="true" class="rvt-m-left-xs" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">

--- a/content/components/overlays/alerts.md
+++ b/content/components/overlays/alerts.md
@@ -30,7 +30,7 @@ events:
 {{< example lang="html" >}}<div class="rvt-alert rvt-alert--info rvt-m-bottom-md" role="alertdialog" aria-labelledby="information-alert-title">
     <h1 class="rvt-alert__title" id="information-alert-title">Scheduled System Maintenance</h1>
     <p class="rvt-alert__message">This system will be unavailable on August 1st due to scheduled system maintenance. Please check back on August 2nd.</p>
-    <button class="rvt-alert__dismiss">
+    <button type="button" class="rvt-alert__dismiss">
         <span class="v-hide">Dismiss this alert</span>
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
             <path fill="currentColor" d="M9.41,8l5.29-5.29a1,1,0,0,0-1.41-1.41L8,6.59,2.71,1.29A1,1,0,0,0,1.29,2.71L6.59,8,1.29,13.29a1,1,0,1,0,1.41,1.41L8,9.41l5.29,5.29a1,1,0,0,0,1.41-1.41Z"/>
@@ -41,7 +41,7 @@ events:
 <div class="rvt-alert rvt-alert--success rvt-m-bottom-md" role="alertdialog" aria-labelledby="success-alert-title">
     <h1 class="rvt-alert__title" id="success-alert-title">Thank you!</h1>
     <p class="rvt-alert__message">We have received your application. Check your email in a few weeks to find out if you’ve been admitted.</p>
-    <button class="rvt-alert__dismiss">
+    <button type="button" class="rvt-alert__dismiss">
         <span class="v-hide">Dismiss this alert</span>
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
             <path fill="currentColor" d="M9.41,8l5.29-5.29a1,1,0,0,0-1.41-1.41L8,6.59,2.71,1.29A1,1,0,0,0,1.29,2.71L6.59,8,1.29,13.29a1,1,0,1,0,1.41,1.41L8,9.41l5.29,5.29a1,1,0,0,0,1.41-1.41Z"/>
@@ -52,7 +52,7 @@ events:
 <div class="rvt-alert rvt-alert--warning rvt-m-bottom-md" role="alertdialog" aria-labelledby="warning-alert-title">
     <h1 class="rvt-alert__title" id="warning-alert-title">Unsaved Changes</h1>
     <p class="rvt-alert__message">Your changes have not been saved. To save your changes, click ‘Save my changes’ or click ‘Cancel’ to exit without saving.</p>
-    <button class="rvt-alert__dismiss">
+    <button type="button" class="rvt-alert__dismiss">
         <span class="v-hide">Dismiss this alert</span>
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
             <path fill="currentColor" d="M9.41,8l5.29-5.29a1,1,0,0,0-1.41-1.41L8,6.59,2.71,1.29A1,1,0,0,0,1.29,2.71L6.59,8,1.29,13.29a1,1,0,1,0,1.41,1.41L8,9.41l5.29,5.29a1,1,0,0,0,1.41-1.41Z"/>
@@ -305,4 +305,3 @@ The Rivet alert component comes with a couple of methods you can use to programm
 ### Available methods
 
 {{< apidocs type="methods" >}}{{< /apidocs >}}
-

--- a/content/components/overlays/modals.md
+++ b/content/components/overlays/modals.md
@@ -46,7 +46,7 @@ events:
             Emitted when the Modal is closed (using the `Modal.close()` method, or the `data-modal-trigger` attribute). The value of the modal `id` attribute is also passed along via the custom event’s detail property and is available to use in your scripts as `event.detail.name()`
 ---
 ## Modal example
-{{< example lang="html" >}}<button class="rvt-button" data-modal-trigger="modal-example-basic">Open modal example</button>
+{{< example lang="html" >}}<button type="button" class="rvt-button" data-modal-trigger="modal-example-basic">Open modal example</button>
 
 <div class="rvt-modal"
      id="modal-example-basic"
@@ -62,10 +62,10 @@ events:
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor <a href="#">incididunt ut labore</a> et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         </div>
         <div class="rvt-modal__controls">
-            <button class="rvt-button">OK</button>
-            <button class="rvt-button rvt-button--secondary" data-modal-close="modal-example-basic">Cancel</button>
+            <button type="button" class="rvt-button">OK</button>
+            <button type="button" class="rvt-button rvt-button--secondary" data-modal-close="modal-example-basic">Cancel</button>
         </div>
-        <button class="rvt-button rvt-modal__close" data-modal-close="modal-example-basic">
+        <button type="button" class="rvt-button rvt-modal__close" data-modal-close="modal-example-basic">
             <span class="rvt-sr-only">Close</span>
             <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
                 <path fill="currentColor" d="M9.41,8l5.29-5.29a1,1,0,0,0-1.41-1.41L8,6.59,2.71,1.29A1,1,0,0,0,1.29,2.71L6.59,8,1.29,13.29a1,1,0,1,0,1.41,1.41L8,9.41l5.29,5.29a1,1,0,0,0,1.41-1.41Z"/>
@@ -101,12 +101,12 @@ The `.rvt-modal__controls` element provides a space to add additional controls l
 ### Modal set up
 To use the modal component you'll need to do a few things. First, add the markup to your document.
 
-{{< code lang="html" >}}<button class="rvt-button" data-modal-trigger="my-modal-id">Open the modal</button>
+{{< code lang="html" >}}<button type="button" class="rvt-button" data-modal-trigger="my-modal-id">Open the modal</button>
 
 <div class="rvt-modal" id="my-modal-id">
     modal markup here...
 
-    <button class="rvt-button rvt-button--plain rvt-modal__close" data-modal-close="my-modal-id">
+    <button type="button" class="rvt-button rvt-button--plain rvt-modal__close" data-modal-close="my-modal-id">
         button markup here...
     </button>
 </div>
@@ -123,7 +123,7 @@ We use the generic term "Modal" to mean any smaller window that is displayed on 
 
 A modal dialog is similar to a regular modal except that **it requires the user to interact with it** before continuing any interaction with the main application. The user must select from the available actions in the dialog—they cannot disregard and simply close the window.
 
-{{< example lang="html" >}}<button class="rvt-button" data-modal-trigger="modal-dialog-example">Open modal dialog</button>
+{{< example lang="html" >}}<button type="button" class="rvt-button" data-modal-trigger="modal-dialog-example">Open modal dialog</button>
 <div class="rvt-modal"
      id="modal-dialog-example"
      role="dialog"
@@ -143,8 +143,8 @@ A modal dialog is similar to a regular modal except that **it requires the user 
             </ul>
         </div>
         <div class="rvt-modal__controls">
-            <button class="rvt-button">Yes</button>
-            <button class="rvt-button rvt-button--secondary" data-modal-close="modal-dialog-example">No, thanks</button>
+            <button type="button" class="rvt-button">Yes</button>
+            <button type="button" class="rvt-button rvt-button--secondary" data-modal-close="modal-dialog-example">No, thanks</button>
         </div>
     </div>
 </div>
@@ -200,4 +200,3 @@ document.addEventListener('modalOpen', event => {
   // Maybe send some data via an AJAX request, etc...
 }, false);
 {{< /code >}}
-

--- a/content/components/page-content/media-object.md
+++ b/content/components/page-content/media-object.md
@@ -89,9 +89,9 @@ The example below features a [checkbox]({{< ref "/components/forms/checkboxes.md
         </svg>
       </button>
       <div class="rvt-dropdown__menu rvt-dropdown__menu--right" id="dropdown-1" role="menu" aria-hidden="true">
-        <button role="menuitemradio">Notify all</button>
-        <button role="menuitemradio" aria-checked="true">Notify admins</button>
-        <button role="menuitemradio">Notify contributors</button>
+        <button type="button" role="menuitemradio">Notify all</button>
+        <button type="button" role="menuitemradio" aria-checked="true">Notify admins</button>
+        <button type="button" role="menuitemradio">Notify contributors</button>
       </div>
     </div>
   </div>

--- a/layouts/add-ons/single.html
+++ b/layouts/add-ons/single.html
@@ -24,7 +24,7 @@
         <div class="rvtd-toolbar__url">
           <span id="package-{{ .Params.packageName | md5 }}">npm install {{ .Params.packageName }}</span>
         </div>
-        <button class="rvt-button rvtd-package-copy" role="button" data-clipboard-target="#package-{{ .Params.packageName | md5 }}">Copy</button>
+        <button type="button" class="rvt-button rvtd-package-copy" role="button" data-clipboard-target="#package-{{ .Params.packageName | md5 }}">Copy</button>
         {{ end }}
       </div>
       <div class="rvtd-toolbar__secondary">

--- a/layouts/changelog/single.html
+++ b/layouts/changelog/single.html
@@ -3,6 +3,7 @@
     <div class="rvtd-sidebar">
         <search-form>
             <button
+                type="button"
                 class="rvt-button button button--secondary rvtd-sidebar__nav-toggle"
                 role="button"
                 :aria-expanded="navIsVisible ? 'true' : 'false'"

--- a/layouts/partials/drawer-button.html
+++ b/layouts/partials/drawer-button.html
@@ -1,5 +1,6 @@
 <!-- Drawer close button - shows on small screens -->
 <button
+    type="button"
     class="rvt-drawer-button"
     role="button"
     aria-label="Toggle navigation options"

--- a/layouts/partials/drawer.html
+++ b/layouts/partials/drawer.html
@@ -7,7 +7,7 @@
         <div class="ts-14 m-top-sm m-bottom-sm text-uppercase">Navigation</div>
         <ul class="hide-on-desktop">
             <li class="has-children">
-                <button role="button" role="button" data-subnav-toggle="documentation-subnav" aria-haspopup="true" aria-expanded="false">Documentation</button>
+                <button type="button" role="button" data-subnav-toggle="documentation-subnav" aria-haspopup="true" aria-expanded="false">Documentation</button>
                 <ul id="documentation-subnav" aria-hidden="true">
                     <li><a href="{{ trim .Site.BaseURL "/" }}/components">Components</a></li>
                     <li><a href="{{ trim .Site.BaseURL "/" }}/add-ons">Add-ons</a></li>
@@ -15,7 +15,7 @@
                 </ul>
             </li>
             <li class="has-children">
-                <button role="button" data-subnav-toggle="about-subnav" aria-haspopup="true" aria-expanded="false">About Rivet</button>
+                <button type="button" role="button" data-subnav-toggle="about-subnav" aria-haspopup="true" aria-expanded="false">About Rivet</button>
                 <ul id="about-subnav" aria-hidden="true">
                     <li><a href="{{ trim .Site.BaseURL "/" }}/about">What is Rivet?</a></li>
                     <li><a href="{{ trim .Site.BaseURL "/" }}/blog">Blog</a></li>
@@ -32,6 +32,6 @@
                 <li><a {{ if ne .self true }}target="_blank"{{ end }} href="{{ .url }}">{{ .text }}</a></li>
             {{ end }}
         </ul>
-        <button class="rvt-drawer__bottom-close">Close nav</button>
+        <button type="button" class="rvt-drawer__bottom-close">Close nav</button>
     </nav>
 </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -17,7 +17,7 @@
                 {{ $currentNav := . }}
                 <li>
                     <div class="rvt-dropdown">
-                        <button class="rvt-dropdown__toggle" data-dropdown-toggle="documentation-dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                        <button type="button" class="rvt-dropdown__toggle" data-dropdown-toggle="documentation-dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                             <span class="rvt-dropdown__toggle-text">Documentation</span>
                             <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
                                 <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
@@ -32,7 +32,7 @@
                 </li>
                 <li>
                     <div class="dropdown">
-                        <button class="dropdown__toggle" data-dropdown-toggle="learn-dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                        <button type="button" class="dropdown__toggle" data-dropdown-toggle="learn-dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                             <span class="rvt-dropdown__toggle-text">About Rivet</span>
                             <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
                                 <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
@@ -61,6 +61,7 @@
             <div class="rvt-hide-lg-down">
                 <div class="rvt-dropdown">
                     <button
+                        type="button"
                         class="rvt-button"
                         data-dropdown-toggle="use-dropdown"
                         role="button"
@@ -89,6 +90,3 @@
     </div>
     {{ partial "drawer.html" . }}
 </header>
-
-
-

--- a/layouts/partials/support-form.html
+++ b/layouts/partials/support-form.html
@@ -1,6 +1,7 @@
 <div class="rvtd-support">
   <div class="rvt-dropdown">
     <button
+      type="button"
       class="rvt-button rvtd-support__toggle"
       type="button"
       data-dropdown="help-dropdown"

--- a/layouts/shortcodes/code.html
+++ b/layouts/shortcodes/code.html
@@ -2,6 +2,7 @@
     <div class="rvtd-example__code rvtd-example__code--only">
         <pre><code id="code_{{ .Inner | md5 }}" class="language-{{ if .Get "lang" }}{{ .Get "lang" }}{{ else }}html{{ end }}">{{- .Inner | string -}}</code></pre>
         <button
+            type="button"
             class="rvtd-example__copy rvtd-example__copy--code-only button button--small"
             data-clipboard-target="#code_{{ .Inner | md5 }}"
             title="Copied"

--- a/layouts/shortcodes/example.html
+++ b/layouts/shortcodes/example.html
@@ -5,6 +5,7 @@
     <div class="rvtd-example__code">
         <pre><code id="code_{{ .Inner | md5 }}" class="language-{{ if .Get "lang" }}{{ .Get "lang" }}{{ else }}html{{ end }}">{{- .Inner | string -}}</code></pre>
         <button
+            type="button"
             class="rvtd-example__copy button button--small"
             data-clipboard-target="#code_{{ .Inner | md5 }}"
             title="Copied"

--- a/layouts/status/single.html
+++ b/layouts/status/single.html
@@ -3,6 +3,7 @@
     <div class="rvtd-sidebar">
         <search-form>
             <button
+                type="button"
                 class="rvt-button button button--secondary rvtd-sidebar__nav-toggle"
                 role="button"
                 :aria-expanded="navIsVisible ? 'true' : 'false'"


### PR DESCRIPTION
This PR addresses issue #35. It adds `type="button"` to buttons which are not intended to be (or demonstrate) submittable buttons. 

@scottanthonymurray I could especially use your feedback on the language for the alert on `buttons.md: line 26`.