### PR TITLE
Added docSearch service 

### DIFF
--- a/assets/scss/_shame.scss
+++ b/assets/scss/_shame.scss
@@ -712,3 +712,142 @@ a.button--reverse-secondary {
 .callout-top-border {
   border-top: 5px #006298 solid;
 }
+
+.algolia-autocomplete {
+    display: block !important;
+}
+
+.algolia-autocomplete a {
+  text-decoration: none;
+}
+
+.algolia-autocomplete .ds-dropdown-menu {
+    width: 100%;
+    min-width: 0 !important;
+    max-width: none !important;
+    padding: .75rem 0 !important;
+    background-color: #fff;
+    background-clip: padding-box;
+    border: none;
+    box-shadow: 0 1px 3px 2px rgba(0,0,0,0.07);
+}
+
+@media (min-width: 768px) {
+    .algolia-autocomplete .ds-dropdown-menu {
+        width:175%
+    }
+}
+
+.algolia-autocomplete .ds-dropdown-menu::before {
+    display: none !important
+}
+
+.algolia-autocomplete .ds-dropdown-menu [class^=ds-dataset-] {
+    padding: 0 !important;
+    overflow: visible !important;
+    background-color: transparent !important;
+    border: 0 !important
+}
+
+.algolia-autocomplete .ds-dropdown-menu .ds-suggestions {
+    margin-top: 0 !important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion {
+    padding: 0 !important;
+    overflow: visible !important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--category-header {
+    padding: .125rem 1rem !important;
+    margin-top: 0 !important;
+    font-size: .875rem !important;
+    font-weight: 600  !important;
+    color: #333333  !important;
+    border-bottom: 0 !important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--wrapper {
+    float: none!important;
+    padding-top: 0!important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--subcategory-column {
+    float: none !important;
+    width: auto !important;
+    padding: 0 !important;
+    text-align: left !important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--subcategory-inline {
+    display: block !important;
+    font-size: .875rem;
+    color: $color-black--700;
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--subcategory-inline::after {
+    padding: 0 .25rem;
+    content: "/"
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--content {
+    display: flex;
+    flex-wrap: wrap;
+    float: none !important;
+    width: 100% !important;
+    padding: .25rem 1rem !important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--content::before {
+    display: none !important
+}
+
+.algolia-autocomplete .ds-suggestion:not(:first-child) .algolia-docsearch-suggestion--category-header {
+    padding-top: .75rem !important;
+    margin-top: .75rem !important;
+    border-top: 1px solid #eaeaea;
+}
+
+.algolia-autocomplete .ds-suggestion .algolia-docsearch-suggestion--subcategory-column {
+    display: none !important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--title {
+    display: block;
+    margin-bottom: 0 !important;
+    font-size: .875rem !important;
+    font-weight: 400 !important
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--text {
+    -ms-flex: 0 0 100%;
+    flex: 0 0 100%;
+    max-width: 100%;
+    padding: .2rem 0;
+    font-size: .8125rem !important;
+    font-weight: 400;
+    line-height: 1.25 !important;
+    color: $color-black--700;
+}
+
+.algolia-autocomplete .algolia-docsearch-footer {
+  float: none;
+  margin-top: $sm;
+}
+
+.algolia-docsearch-footer--logo {
+  margin-left: $sm;
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--highlight {
+    color: $color-blue--500;
+    background-color: $color-blue--050;
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--text .algolia-docsearch-suggestion--highlight {
+    box-shadow: inset 0 -2px 0 0 $color-blue--050 !important
+}
+
+.algolia-autocomplete .ds-suggestion.ds-cursor .algolia-docsearch-suggestion--content {
+    background-color: $color-blue--050 !important
+}

--- a/assets/scss/_shame.scss
+++ b/assets/scss/_shame.scss
@@ -851,3 +851,28 @@ a.button--reverse-secondary {
 .algolia-autocomplete .ds-suggestion.ds-cursor .algolia-docsearch-suggestion--content {
     background-color: $color-blue--050 !important
 }
+
+.rvtd-search-form {
+  position: relative;
+}
+
+.rvtd-nav-toggle {
+  width: $xl;
+  height: $xl;
+  justify-content: center;
+  padding: 0;
+  position: absolute;
+  right: $md - .125rem;
+  bottom: -$md * .9;
+  border-radius: 999rem;
+  
+  &[aria-expanded="true"] svg {
+    transform: rotate(180deg);
+  }
+}
+
+@include mq($breakpoint-md) {
+  .rvtd-nav-toggle {
+    display: none;
+  }
+}

--- a/assets/scss/components/_rvtd-layout.scss
+++ b/assets/scss/components/_rvtd-layout.scss
@@ -14,11 +14,10 @@
 
 .rvtd-nav {
     padding: $md;
-    display: none;
 }
 
-.rvtd-nav.is-visible {
-    display: block;
+.rvtd-nav[aria-hidden="true"] {
+    display: none;
 }
 
 @include mq(bp(md)) {

--- a/layouts/changelog/single.html
+++ b/layouts/changelog/single.html
@@ -1,20 +1,7 @@
 {{ define "main" }}
 <div class="rvtd-wrap">
     <div class="rvtd-sidebar">
-        <search-form>
-            <button
-                class="rvt-button button button--secondary rvtd-sidebar__nav-toggle"
-                role="button"
-                :aria-expanded="navIsVisible ? 'true' : 'false'"
-                aria-haspopup="true"
-                @click="toggleNav"
-            >
-                <span class="sr-only">Toggle components menu</span>
-                <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-                    <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
-                </svg>
-            </button>
-        </search-form>
+        {{ partial "search-form" . }}
         {{ partial "section-nav.html" .}}
     </div>
     <div class="rvtd-tube rvtd-tube--full-width">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -9,5 +9,6 @@
     {{ end }}
     <title>{{ .Page.Title | markdownify | plainify }} - {{ .Site.Title }} {{ .Site.Params.tagline }}</title>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/github.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
     <link rel="stylesheet" href="{{ "css/style.css" | relURL }}?{{ now.Unix }}">
 </head>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -6,8 +6,20 @@
 {{ end }}
 <script src="{{ "js/telemetrics.js" | absURL }}"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
+
+<script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+
 <script>
     hljs.initHighlightingOnLoad();
     var baseURL = "{{ .Site.BaseURL }}";
+</script>
+
+<script>
+    docsearch({
+        apiKey: '21932cb0064dada05e60ee0e7cbf98fa',
+        indexName: 'rivet_iu',
+        inputSelector: '#docs-search',
+        debug: true // Set debug to true if you want to inspect the dropdown
+    });
 </script>
 <script src="{{ "js/rivet-docs.js" | absURL }}?{{ now.Unix }}"></script>

--- a/layouts/partials/search-form.html
+++ b/layouts/partials/search-form.html
@@ -1,6 +1,6 @@
 <div class="rvtd-search-form">
   <form role="search">
-    <div class="rvt-p-lr-md rvt-p-top-md rvt-p-bottom-lg rvt-p-bottom-md-md-up rvt-border-bottom">
+    <div class="rvt-p-all-lg rvt-p-all-md-md-up rvt-border-bottom">
       <label for="docs-search" class="rvt-sr-only">Search the docs</label>
       <input type="text" id="docs-search" placeholder="Search the docs">
     </div>

--- a/layouts/partials/search-form.html
+++ b/layouts/partials/search-form.html
@@ -1,0 +1,14 @@
+<div class="rvtd-search-form">
+  <form role="search">
+    <div class="rvt-p-lr-md rvt-p-top-md rvt-p-bottom-lg rvt-p-bottom-md-md-up rvt-border-bottom">
+      <label for="docs-search" class="rvt-sr-only">Search the docs</label>
+      <input type="text" id="docs-search" placeholder="Search the docs">
+    </div>
+  </form>
+  <button type="button" class="rvt-button rvtd-nav-toggle" data-dropdown-toggle="main-nav">
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+      <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
+    </svg>
+    <span class="rvt-sr-only">Toggle menu</span>
+  </button>
+</div>

--- a/layouts/partials/section-nav.html
+++ b/layouts/partials/section-nav.html
@@ -1,7 +1,7 @@
 <!-- Capture the current page here -->
 {{ $currentPage := . }}
 {{ $currentParentSection := .Section }}
-<nav class="rvtd-nav" :class="{ 'is-visible' : navIsVisible }" role="navigation" aria-label="section">
+<nav class="rvtd-nav" role="navigation" aria-label="section" aria-hidden="true" id="main-nav">
     <span class="rvt-m-bottom-md rvt-display-block">Version <span class="rvt-text-bold">{{ .Site.Params.rivetVersion }}</span></span>
     <ul class="rvtd-toc">
         {{ range where .Site.Sections "Section" $currentParentSection }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,17 +1,7 @@
 <div class="rvtd-sidebar">
-    <search-form>
-        <button
-            class="rvt-button button button--secondary rvtd-sidebar__nav-toggle"
-            role="button"
-            :aria-expanded="navIsVisible ? 'true' : 'false'"
-            aria-haspopup="true"
-            @click="toggleNav"
-        >
-            <span class="sr-only">Toggle components menu</span>
-            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-                <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
-            </svg>
-        </button>
-    </search-form>
-    {{ partial "section-nav.html" . }}
+  <div class="rvt-p-all-md rvt-border-bottom">
+    <label for="docs-search" class="rvt-sr-only">Search the docs</label>
+    <input type="text" id="docs-search">
+  </div>
+  {{ partial "section-nav.html" . }}
 </div>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,9 +1,4 @@
 <div class="rvtd-sidebar">
-  <form role="search">
-    <div class="rvt-p-all-md rvt-border-bottom">
-      <label for="docs-search" class="rvt-sr-only">Search the docs</label>
-      <input type="text" id="docs-search" placeholder="Search the docs">
-    </div>
-  </form>
+  {{ partial "search-form" . }}
   {{ partial "section-nav.html" . }}
 </div>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,7 +1,9 @@
 <div class="rvtd-sidebar">
-  <div class="rvt-p-all-md rvt-border-bottom">
-    <label for="docs-search" class="rvt-sr-only">Search the docs</label>
-    <input type="text" id="docs-search">
-  </div>
+  <form role="search">
+    <div class="rvt-p-all-md rvt-border-bottom">
+      <label for="docs-search" class="rvt-sr-only">Search the docs</label>
+      <input type="text" id="docs-search" placeholder="Search the docs">
+    </div>
+  </form>
   {{ partial "section-nav.html" . }}
 </div>

--- a/layouts/status/single.html
+++ b/layouts/status/single.html
@@ -1,20 +1,7 @@
 {{ define "main" }}
 <div class="rvtd-wrap">
     <div class="rvtd-sidebar">
-        <search-form>
-            <button
-                class="rvt-button button button--secondary rvtd-sidebar__nav-toggle"
-                role="button"
-                :aria-expanded="navIsVisible ? 'true' : 'false'"
-                aria-haspopup="true"
-                @click="toggleNav"
-            >
-                <span class="sr-only">Toggle components menu</span>
-                <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-                    <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
-                </svg>
-            </button>
-        </search-form>
+        {{ partial "search-form" . }}
         {{ partial "section-nav.html" .}}
     </div>
     <div class="rvtd-tube">


### PR DESCRIPTION
This PR adds the Algolia docSearch service to the Rivet documentation site. You can read more about docSearch here:

https://community.algolia.com/docsearch/

This service is only available on the main rivet.iu.edu domain, so this PR will need to be merged into master instead of develop.