### PR TITLE
Updated footer and support widget external links to open in tab

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,14 +8,14 @@
           <polygon points="13.33 3.32 13.33 5.21 14.76 5.21 14.76 15.64 11.9 15.64 11.9 1.9 13.33 1.9 13.33 0 6.67 0 6.67 1.9 8.09 1.9 8.09 15.64 5.24 15.64 5.24 5.21 6.67 5.21 6.67 3.32 0 3.32 0 5.21 1.43 5.21 1.43 17.47 3.7 19.91 8.09 19.91 8.09 22.76 6.67 22.76 6.67 25.13 13.33 25.13 13.33 22.76 11.9 22.76 11.9 19.91 16.1 19.91 18.56 17.47 18.56 5.21 20 5.21 20 3.32 13.33 3.32" fill="#900"/>
         </svg>
       </div>
-      <p><a href="https://www.iu.edu/copyright/index.html">Copyright</a> &copy; <span id="year"></span> The Trustees of <a href="https://www.iu.edu/">Indiana University</a></p>
+      <p><a href="https://www.iu.edu/copyright/index.html" target="_blank" rel="noopener">Copyright</a> &copy; <span id="year"></span> The Trustees of <a href="https://www.iu.edu/" target="_blank" rel="noopener">Indiana University</a></p>
     </div>
     <ul class="rvt-footer__privacy-link">
       <li class="rvt-footer__aux-item">
-        <a href="https://uxo.iu.edu/privacy/">Privacy Policy</a>
+        <a href="https://uxo.iu.edu/privacy/" target="_blank" rel="noopener">Privacy Notice</a>
       </li>
       <li class="rvt-footer__aux-item rvt-footer__aux-item--no-divider">
-        <a href="https://accessibility.iu.edu/">Accessibility Help</a>
+        <a href="https://accessibility.iu.edu/assistance/" target="_blank" rel="noopener">Accessibility</a>
       </li>
       <li class="rvt-footer__aux-item rvt-footer__contact-link rvt-footer__aux-item--no-divider rvt-m-right-xl">
         <a role="button" href="javascript:void(0)" data-modal-trigger="modal-support-form">Contact</a>
@@ -23,10 +23,10 @@
     </ul>
     <ul class="rvt-footer__aux-links rvt-footer__org-links">
       <li class="rvt-footer__aux-item rvt-footer__aux-item--no-divider rvt-m-right-sm">
-        <a href="https://it.iu.edu/ovpit/">Office of the Vice President for <abbr title="Information Technology">IT</abbr></a>
+        <a href="https://it.iu.edu/ovpit/" target="_blank" rel="noopener">Office of the Vice President for <abbr title="Information Technology">IT</abbr></a>
       </li>
       <li class="rvt-footer__aux-item">
-        <a href="https://uits.iu.edu">
+        <a href="https://uits.iu.edu" target="_blank" rel="noopener">
           <img src="https://uxo.iu.edu/img/uits.png" class="rvt-footer__uits" alt="University Information Technology Services" />
         </a>
       </li>

--- a/layouts/partials/support-form.html
+++ b/layouts/partials/support-form.html
@@ -18,7 +18,7 @@
           Have a question about Rivet?
         </div>
         <p>We're happy to help! If you've found a bug, typo, or have a request, the best way
-        to get in touch is to <a href="{{ .Site.Params.githubRepo}}/issues">create an issue on Github</a>.</p>
+        to get in touch is to <a href="{{ .Site.Params.githubRepo}}/issues" target="_blank" rel="noopener">create an issue on Github</a>.</p>
         <p>For all other questions please feel free to email us at <a href="mailto:rivet@iu.edu">rivet@iu.edu</a></p>
       </div>
     </div>


### PR DESCRIPTION
This PR adds `target="_blank" rel="noopener` where appropriate to open external links in new tabs in the footer and support popup.