### PR TITLE
Added standard items to the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ yarn-error.log*
 _demo/
 
 # rivet-docs specific
-.idea
 .vscode
 public/
 tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,36 @@
-.idea
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# testing
+/coverage
+cypress/videos/
+
+# production
+/build
+.npmrc
+
+# misc
 .DS_Store
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.idea
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+*.p8
+
+_demo/
+
+# rivet-docs specific
+.idea
 .vscode
-node_modules
 public/
 tmp/
 kb-api.json


### PR DESCRIPTION
Updated `.gitignore` file to include newly standardized items such as .env files, debug logs, etc. See issue #39.