### PR TITLE
Made updates to reflect changes for 1.4.0 release

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -10,12 +10,12 @@ taxonomies:
 outputs:
   section: ["html"]
 params:
-  rivetVersion: 1.3.0
+  rivetVersion: 1.4.0
   tagline: "Design System"
   googleAnalytics: "UA-100560495-3"
   devGoogleAnalytics: "UA-100560495-4"
   githubRepo: "https://github.com/indiana-university/rivet-source"
-  downloadLink: "https://github.com/indiana-university/rivet-source/releases/download/v1.3.0/rivet.zip"
+  downloadLink: "https://github.com/indiana-university/rivet-source/releases/download/v1.4.0/rivet.zip"
   axureKit: "https://github.iu.edu/UITS/rivet/releases/download/v1.0.0/rivet-axure-1.0.rp"
   description: "Use Rivet to create UITS software that is accessible, usable, and consistent."
   resourceLinks:

--- a/content/components/_index.md
+++ b/content/components/_index.md
@@ -19,7 +19,7 @@ The Rivet components documentation contains examples, code snippets, and guidanc
 ## Download Rivet
 You can download a ZIP file that contains the compiled and minified CSS and JavaScript, images, and a starter HTML file.
 
-{{< button url="https://github.com/indiana-university/rivet-source/releases/download/v1.3.0/rivet.zip" variant="secondary" analytics-action="download" analytics-category="click">}}
+{{< button url="https://github.com/indiana-university/rivet-source/releases/download/v1.4.0/rivet.zip" variant="secondary" analytics-action="download" analytics-category="click">}}
     <span class="rvt-m-right-xs">Download Rivet</span>
     <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
         <g fill="currentColor">
@@ -85,7 +85,7 @@ In previous versions of Rivet a .npmrc file configured to look at IU's public re
 ### Installing via NPM
 Once you have a `package.json` file configured in the root of your project, you can run the following command to install Rivet.
 
-{{< code >}}npm install rivet-uits@1.3.0 --save-dev
+{{< code >}}npm install rivet-uits@1.4.0 --save-dev
 {{< /code >}}
 
 ### Updating the Rivet NPM package
@@ -103,11 +103,11 @@ The hosted CSS and JavaScript assets are a good solution for prototyping ideas, 
 
 The quickest way to get started with Rivet is using the centrally-hosted CSS and JavaScript files. Copy and paste this `<link>` element to `<head>` of your document. Make sure it is placed **before** any other stylesheets.
 
-{{< code lang="html" analytics-label="assets.uits.iu.edu/css link tag">}}<link rel="stylesheet" href="https://assets.uits.iu.edu/css/rivet/1.3.0/rivet.min.css">{{< /code >}}
+{{< code lang="html" analytics-label="assets.uits.iu.edu/css link tag">}}<link rel="stylesheet" href="https://assets.uits.iu.edu/css/rivet/1.4.0/rivet.min.css">{{< /code >}}
 
 Rivet has a minimal amount of JavaScript that is required for some components, like the [header](../components/navigation/header). Copy and paste this link and add to the end of your document, just before the closing `</body>` tag.
 
-{{< code lang="html" analytics-label="assets.uits.iu.edu/js script tag">}}<script src="https://assets.uits.iu.edu/javascript/rivet/1.3.0/rivet.min.js"></script>{{< /code >}}
+{{< code lang="html" analytics-label="assets.uits.iu.edu/js script tag">}}<script src="https://assets.uits.iu.edu/javascript/rivet/1.4.0/rivet.min.js"></script>{{< /code >}}
 
 ## Starter template
 Here's a basic starter template with the hosted CSS and JavaScript hooked up. Copy and paste into your favorite editor to start using Rivet.
@@ -118,7 +118,7 @@ Here's a basic starter template with the hosted CSS and JavaScript hooked up. Co
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://assets.uits.iu.edu/css/rivet/1.3.0/rivet.min.css">
+    <link rel="stylesheet" href="https://assets.uits.iu.edu/css/rivet/1.4.0/rivet.min.css">
     <title>Rivet starter file</title>
 </head>
 <body>
@@ -164,7 +164,7 @@ Here's a basic starter template with the hosted CSS and JavaScript hooked up. Co
             </li>
         </ul>
     </footer>
-    <script src="https://assets.uits.iu.edu/javascript/rivet/1.3.0/rivet.min.js"></script>
+    <script src="https://assets.uits.iu.edu/javascript/rivet/1.4.0/rivet.min.js"></script>
 </body>
 </html>
 {{< /code >}}

--- a/content/components/overlays/alerts.md
+++ b/content/components/overlays/alerts.md
@@ -30,7 +30,7 @@ events:
 {{< example lang="html" >}}<div class="rvt-alert rvt-alert--info rvt-m-bottom-md" role="alertdialog" aria-labelledby="information-alert-title">
     <h1 class="rvt-alert__title" id="information-alert-title">Scheduled System Maintenance</h1>
     <p class="rvt-alert__message">This system will be unavailable on August 1st due to scheduled system maintenance. Please check back on August 2nd.</p>
-    <button type="button" class="rvt-alert__dismiss">
+    <button type="button" class="rvt-alert__dismiss" data-alert-close>
         <span class="v-hide">Dismiss this alert</span>
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
             <path fill="currentColor" d="M9.41,8l5.29-5.29a1,1,0,0,0-1.41-1.41L8,6.59,2.71,1.29A1,1,0,0,0,1.29,2.71L6.59,8,1.29,13.29a1,1,0,1,0,1.41,1.41L8,9.41l5.29,5.29a1,1,0,0,0,1.41-1.41Z"/>
@@ -41,7 +41,7 @@ events:
 <div class="rvt-alert rvt-alert--success rvt-m-bottom-md" role="alertdialog" aria-labelledby="success-alert-title">
     <h1 class="rvt-alert__title" id="success-alert-title">Thank you!</h1>
     <p class="rvt-alert__message">We have received your application. Check your email in a few weeks to find out if you’ve been admitted.</p>
-    <button type="button" class="rvt-alert__dismiss">
+    <button type="button" class="rvt-alert__dismiss" data-alert-close>
         <span class="v-hide">Dismiss this alert</span>
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
             <path fill="currentColor" d="M9.41,8l5.29-5.29a1,1,0,0,0-1.41-1.41L8,6.59,2.71,1.29A1,1,0,0,0,1.29,2.71L6.59,8,1.29,13.29a1,1,0,1,0,1.41,1.41L8,9.41l5.29,5.29a1,1,0,0,0,1.41-1.41Z"/>
@@ -52,7 +52,7 @@ events:
 <div class="rvt-alert rvt-alert--warning rvt-m-bottom-md" role="alertdialog" aria-labelledby="warning-alert-title">
     <h1 class="rvt-alert__title" id="warning-alert-title">Unsaved Changes</h1>
     <p class="rvt-alert__message">Your changes have not been saved. To save your changes, click ‘Save my changes’ or click ‘Cancel’ to exit without saving.</p>
-    <button type="button" class="rvt-alert__dismiss">
+    <button type="button" class="rvt-alert__dismiss" data-alert-close>
         <span class="v-hide">Dismiss this alert</span>
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
             <path fill="currentColor" d="M9.41,8l5.29-5.29a1,1,0,0,0-1.41-1.41L8,6.59,2.71,1.29A1,1,0,0,0,1.29,2.71L6.59,8,1.29,13.29a1,1,0,1,0,1.41,1.41L8,9.41l5.29,5.29a1,1,0,0,0,1.41-1.41Z"/>
@@ -300,7 +300,15 @@ See the [content guide section](/content-guide) for additional information.
 - Write helpful alert messages. For errors, Include a brief description of the problem and how to fix it. Check out the Voice and tone/microcopy section for more information.
 
 ## JavaScript API
-The Rivet alert component comes with a couple of methods you can use to programmatically control alerts. The `.init()` method is called by default the first `rivet.js` is loaded. You can dismiss alerts using the `.rvt-alert__dismiss` button, or use the `Alert.dismiss()` method in your own script.
+The Rivet alert component comes with a couple of methods you can use to programmatically control alerts. The `.init()` method is called by default the first `rivet.js` is loaded. Alerts are dismissed when clicking a `button` element within the alert with the `data-alert-close` attribute. You can also dismiss an alert by calling the `Alert.dismiss()` method in your own script.
+
+{{< alert variant="warning" title="Alert dismissal class deprecation" >}}
+In previous versions of Rivet, alerts were dismissed by adding the `.rvt-alert__dismiss` class to a `button` element within the alert itself. 
+
+In an effort to [decouple CSS classes from JavaScript behavior](https://github.com/indiana-university/rivet-source/issues/85), this approach has been deprecated in favor of adding the `data-alert-close` attribute to the dismiss button. The examples on this page have been updated to reflect this new approach. 
+
+We recommend updating your application to use the latest version of the alert.
+{{< /alert >}}
 
 ### Available methods
 

--- a/content/components/overlays/alerts.md
+++ b/content/components/overlays/alerts.md
@@ -300,12 +300,12 @@ See the [content guide section](/content-guide) for additional information.
 - Write helpful alert messages. For errors, Include a brief description of the problem and how to fix it. Check out the Voice and tone/microcopy section for more information.
 
 ## JavaScript API
-The Rivet alert component comes with a couple of methods you can use to programmatically control alerts. The `.init()` method is called by default the first `rivet.js` is loaded. Alerts are dismissed when clicking a `button` element within the alert with the `data-alert-close` attribute. You can also dismiss an alert by calling the `Alert.dismiss()` method in your own script.
+The Rivet alert component comes with a couple of methods you can use to programmatically control alerts. The `init()` method is called by default when `rivet.js` is loaded. Alerts are dismissed when clicking a `button` element within the alert with the `data-alert-close` attribute. You can also dismiss an alert by calling the `Alert.dismiss()` method in your own script.
 
 {{< alert variant="warning" title="Alert dismissal class deprecation" >}}
-In previous versions of Rivet, alerts were dismissed by adding the `.rvt-alert__dismiss` class to a `button` element within the alert itself. 
+In previous versions of Rivet, alerts were dismissed by clicking a `button` element within the alert with the `.rvt-alert__dismiss` class. 
 
-In an effort to [decouple CSS classes from JavaScript behavior](https://github.com/indiana-university/rivet-source/issues/85), this approach has been deprecated in favor of adding the `data-alert-close` attribute to the dismiss button. The examples on this page have been updated to reflect this new approach. 
+In an effort to [decouple CSS classes from JavaScript behavior](https://github.com/indiana-university/rivet-source/issues/85), the `.rvt-alert__dismiss` class has been deprecated in favor of the `data-alert-close` attribute. The examples on this page have been updated to reflect this new approach. 
 
 We recommend updating your application to use the latest version of the alert.
 {{< /alert >}}

--- a/content/components/overlays/loading-indicator.md
+++ b/content/components/overlays/loading-indicator.md
@@ -20,13 +20,19 @@ It can be helpful to indicate that the submit button is in an inactive/loading s
 While the button is in the loading state, the `aria-busy="true"` and `disabled` attributes should be applied. This helps prevent users from trying to resubmit data while the current form is being submitted.
 
 {{< example lang="html" >}}<button class="rvt-button rvt-button--loading" aria-busy="true" disabled>
-  <span class="rvt-button__text">Update settings</span>
+  <span class="rvt-button__content">Update settings</span>
   <div class="rvt-loader rvt-loader--xs" aria-label="Content loading"></div>
 </button>
 {{< /example >}}
 
 ### Handling button text display while in the loading state
-When using the loading indicator inside buttons, the visible button text should be wrapped in a `.rvt-button__text` class (see above example). This class visually hides the button text when the loading indicator is visible while maintaining the display width of the button.
+When using the loading indicator inside buttons, the visible button text should be wrapped in a `.rvt-button__content` class (see above example). This class visually hides the button text when the loading indicator is visible while maintaining the display width of the button. This class also hides any other content inside the button, such as SVG icons.
+
+{{< alert variant="warning" title="Class deprecation" >}}
+In previous versions of Rivet, we used the `.rivet-button__text` class to wrap a button’s content. However, we realized that the class name implied that non-text button content such as icons did not need to be wrapped to be hidden. 
+
+If you are using `.rivet-button__text`, please update your application to use the new `.rivet-button__content` class, as the previous class is now deprecated.
+{{< /alert >}}
 
 ## Loading indicator sizes
 The loading indicator comes in multiple sizes that follow the standard Rivet size naming conventions used for [spacing]({{< ref "/components/layout/spacing.md" >}}) and [typography]({{< ref "components/layout/typography.md" >}}).

--- a/content/components/utilities/display.md
+++ b/content/components/utilities/display.md
@@ -37,6 +37,12 @@ The Rivet `rvt-display-*` utilities can be used to easily change the css `displa
 {{< example lang="html" >}}<span class="rvt-display-block bg-green">Display block</span>
 {{< /example >}}
 
+{{< alert variant="warning" title="Class deprecation" >}}
+In previous versions of Rivet, we used the `.rvt-display-flex` and `.rvt-vertical-center` classes to lay out items in a container. These classes are now deprecated in favor of the new [Rivet flex utility classes](https://rivet.iu.edu/components/utilities/flex/). 
+
+If you are using `.rvt-display-flex` or `.rvt-vertical-center`, please update your application to use the new flex utility classes.
+{{< /alert >}}
+
 {{< example lang="html" >}}<div class="rvt-display-flex">
     <div class="bg-orange rvt-m-right-sm">Flex child</div>
     <div class="bg-orange rvt-m-right-sm">Flex child</div>

--- a/data/changelog.json
+++ b/data/changelog.json
@@ -1,5 +1,34 @@
 [
   {
+    "tag_name": "v1.4.0",
+    "published_at": "2019-03-27T17:23:27Z",
+    "body": "This release makes some updates to the Rivet footer and deprecates classes related to alerts and the loading indicator.<!-- end-overview -->",
+    "pulls": {
+      "items": [
+        {
+          "title": "Added optional alert dismissal data selector",
+          "html_url": "https://github.com/indiana-university/rivet-source/pull/94"
+        },
+        {
+          "title": "Deprecated variable color-subtle-gray",
+          "html_url": "https://github.com/indiana-university/rivet-source/pull/93"
+        },
+        {
+          "title": "Deprecated footer copyright markup element",
+          "html_url": "https://github.com/indiana-university/rivet-source/pull/89"
+        },
+        {
+          "title": "Updated footer to reflect new IU standards for link order and text",
+          "html_url": "https://github.com/indiana-university/rivet-source/pull/88"
+        },
+        {
+          "title": "Updated button loading indicator markup to be clear that it works with text and icons",
+          "html_url": "https://github.com/indiana-university/rivet-source/pull/86"
+        }
+      ]
+    }
+  },
+  {
     "tag_name": "v1.3.0",
     "created_at": "2019-02-25T16:47:18Z",
     "published_at": "2019-02-25T17:23:27Z",

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -75,7 +75,7 @@
       "alias": "xl"
     },
     {
-      "size": 48,
+      "size": 64,
       "alias": "xxl"
     }
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -4319,7 +4319,7 @@
     },
     "good-listener": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "resolved": "https://apps.iu.edu/nxs-prd/content/groups/external-npm/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
       "dev": true,
       "requires": {
@@ -8592,9 +8592,9 @@
       "dev": true
     },
     "rivet-uits": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/rivet-uits/-/rivet-uits-1.3.0.tgz",
-      "integrity": "sha512-peM16bOWq7YrDRzysHuLA+BxXq4t1h1h6qjXERfhD+2peEXJ+1+Ilwx5L7u/MmPaVRdz/5oEyH5SywcYUmRSHQ==",
+      "version": "1.4.0-alpha",
+      "resolved": "https://registry.npmjs.org/rivet-uits/-/rivet-uits-1.4.0-alpha.tgz",
+      "integrity": "sha512-VHTbRF9fkSt61hvU1GQrX9YtGEAwbsElyenoaSSNKg62vkXJYjJjCkpULu5gZRD9/tsstF8cRtNihhuBv6pbmw==",
       "dev": true
     },
     "rx": {
@@ -8703,7 +8703,7 @@
     },
     "select": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "resolved": "https://apps.iu.edu/nxs-prd/content/groups/external-npm/select/-/select-1.1.2.tgz",
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "path": "0.12.7",
     "remove-markdown": "0.2.2",
     "require-dir": "0.3.2",
-    "rivet-uits": "^1.3.0",
+    "rivet-uits": "^1.4.0-alpha",
     "striptags": "3.0.1",
     "tippy.js": "^1.2.0",
     "webpack": "^3.10.0"


### PR DESCRIPTION
This PR makes documentation updates to reflect the changes in Rivet 1.4.0.

@illusivesunrae @scottanthonymurray I'm getting this PR open for the 1.4.0 updates to the docs site. 

Trying out something new here with GitHub markdown [task lists](https://help.github.com/en/articles/about-task-lists) (see above). If you're working on any of these to-do feel free to check them off as you push commits that address any item on the list.

## To-dos

- [x] Update docs for button loading state. [See PR on rivet-source](https://github.com/indiana-university/rivet-source/pull/86).
- [x] Update footer documentation to reflect new standards [See PR on rivet-source](https://github.com/indiana-university/rivet-source/pull/88)
- [x] Add docs for footer copyright deprecation alert. See above footer standards to-do and [PR on rivet-source](https://github.com/indiana-university/rivet-source/pull/89).
- [x] Update docs with new data attribute sector for dismissable alerts. [See PR on rivet-source](https://github.com/indiana-university/rivet-source/pull/94)
- [X] Update pixel value for xxl variable in spacing documentation. See #68 for more info.
- [x] Update Rivet version once 1.4.0 RC/alpha is published to npm.
- [x] Update changelog file to include [PRs labeled for this release](https://github.com/indiana-university/rivet-source/pulls?q=is%3Apr+is%3Aclosed+label%3A1.4.0).
- [x] Update version numbers where appropriate in documentation. E.g. in `config.yml`