### PR TITLE
Fixed dateFormat syntax to work in Hugo 0.55

### DIFF
--- a/layouts/partials/notifications-menu.html
+++ b/layouts/partials/notifications-menu.html
@@ -21,7 +21,7 @@
           {{ end }}
             <article class="rvt-notification">
               <time class="rvt-notification__time">
-                {{ dateFormat "January 2, 2006" .Params.date }}
+                {{ dateFormat "January 2, 2006" .Date }}
               </time>
               <h1 class="rvt-notification__title">{{ .Params.title }}</h1>
               <p class="rvt-notification__teaser">{{ .Params.description }}</p>


### PR DESCRIPTION
Updating to Hugo `0.55` caused the date formatter function call in the notifications menu partial to see `.Params.date` as null and throw an error.