### PR TITLE
Added missing markdownify function call to a11y shortcode

### DIFF
--- a/layouts/shortcodes/a11y.html
+++ b/layouts/shortcodes/a11y.html
@@ -1,1 +1,1 @@
-<div class="rvtd-a11y">{{ .Inner }}</div>
+<div class="rvtd-a11y">{{ .Inner | markdownify }}</div>


### PR DESCRIPTION
Hotfix, will backmerge into `develop`