### PR TITLE
Backmerge a11y shortcode hotfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivet-docs",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Rivet design system documentation website",
   "main": "index.html",
   "author": "Indiana University",


### PR DESCRIPTION
This PR backmerges the hotfix made to `master` #111 to add the missing `markdownify` function call to the a11y shortcode