### PR TITLE
Updated Algolia search box z-index to prevent it from overlapping drawer on mobile

### DIFF
--- a/assets/scss/_shame.scss
+++ b/assets/scss/_shame.scss
@@ -797,7 +797,7 @@ a.button--reverse-secondary {
 
 .algolia-autocomplete {
     display: block !important;
-    z-index: 1000;
+    z-index: 100 !important;
 }
 
 .algolia-autocomplete a {


### PR DESCRIPTION
A `z-index` of 100 was chosen because it's less than 1000 (the drawer `z-index`) and matches the `z-index` of other elements of the Algolia box.

Fixes #109 