### PR TITLE
Fixed IE11 footer display issue

### DIFF
--- a/assets/scss/_shame.scss
+++ b/assets/scss/_shame.scss
@@ -966,3 +966,39 @@ a.button--reverse-secondary {
   display: block;
   border-radius: 999rem;
 }
+
+@media screen and (max-width: 740px) {
+  .rvt-footer.rvt-footer--hugo {
+    .rvt-footer__mobile-wrapper { 
+      display: flex;
+      flex-direction: column;
+    }
+    .rvt-footer__copyright-lockup {
+      display: flex;
+      position: static;
+      bottom: unset;
+    }  
+    
+    .rvt-footer__privacy-link {
+          left: 43%;
+          position: static;
+          font-size: $ts-12;
+      }
+      .rvt-footer__org-links {
+        position: static;
+        bottom: unset;
+
+          li:first-child {
+              margin-left: 0px;
+          }
+      }
+  }
+}
+
+@media screen and (max-width: 950px) {
+  .rvt-footer.rvt-footer--hugo {
+    .rvt-footer__privacy-link {
+      left: 35%;
+    }
+  }
+}

--- a/assets/scss/components/_rvtd-layout.scss
+++ b/assets/scss/components/_rvtd-layout.scss
@@ -1,13 +1,9 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-.rvtd-wrap {
-    display: flex;
-    flex-direction: column;
-}
-
 @include mq(bp(md)) {
     .rvtd-wrap {
+        display: flex;
         flex-direction: row;
     }
 }

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 {{ partial "support-form.html" . }}
-<footer class="rvt-footer" role="contentinfo">
+<footer class="rvt-footer rvt-footer--hugo" role="contentinfo">
   <div class="rvt-footer__mobile-wrapper">
     <div class="rvt-footer__copyright-lockup">
       <div class="rvt-footer__trident">


### PR DESCRIPTION
Fixed .rvtd-wrap issue, and added targeted css for docs site footer to prevent bunching of text. This addresses issue #108. 