### PR TITLE
Updated instructions for using icons inside buttons

### DIFF
--- a/content/components/forms/buttons.md
+++ b/content/components/forms/buttons.md
@@ -72,6 +72,7 @@ You can use icons inside the `<button>` element. (Just make sure to also include
 
 1. Wrap the button text in a `<span>` element
 2. Use Rivet’s utility classes to add some space between the button text and the icon
+3. When adding icons to Rivet buttons, all icons should appear before the buttons text except for standard conventions like dropdown menus.
 
 For best results, use an SVG icon that is sized to 16px by 16px.
 


### PR DESCRIPTION
This PR updates the instructions regarding the use of icons within buttons to clarify that icons should appear before any text unless standard conventions are to appear after (such as for a dropdown menu).
See issue #56 for more details.