### PR TITLE
Fixed public folder generation issues

### DIFF
--- a/assets/scss/_shame.scss
+++ b/assets/scss/_shame.scss
@@ -996,12 +996,12 @@ a.button--reverse-secondary {
  * Roadmap overrides
  */
 
- @include mq($breakpoint-md) {
-   .rvt-d-roadmap-timeline {
-     padding-left: 6rem;
-   }
- }
- 
+@include mq($breakpoint-md) {
+  .rvt-d-roadmap-timeline {
+    padding-left: 6rem;
+  }
+}
+
 .rvtd-2-banner {
   background-color: $color-black--100;
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,8 +21,8 @@ function watchFiles(callback) {
     notify: false
   });
 
-  watch('assets/js/**/*.js', { ignoreInitial: false }, series(js.transpileJS, js.concatJS));
-  watch('assets/scss/**/*.scss', { ignoreInitial: false }, sass);
+  watch('assets/js/**/*.js', { ignoreInitial: false }, series(js.transpileJS, js.concatJS, hugoDev));
+  watch('assets/scss/**/*.scss', { ignoreInitial: false }, series(sass, hugoDev));
   watch('content/**/*.md');
   watch(
     [

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,10 +49,11 @@ function hugoDev(callback) {
   callback();
 }
 
-function hugoProd() {
+function hugoProd(callback) {
   hugo(false);
+  callback();
 }
 
-exports.build = series(envProd, sass, js.transpileJS, js.concatJS);
+exports.build = series(envProd, sass, js.transpileJS, js.concatJS, hugoProd);
 
 exports.serve = series(hugoDev, watchFiles);


### PR DESCRIPTION
The `public` folder was not being regenerated during the build process (both dev and prod). Configured the `hugoProd` function to run at the end of the build process, and configured the `hugoDev` function to run when updates are made to `.js` and `.scss` files during the `watch` process.

See issue #147 for more details.