### PR TITLE
Removed hugoProd command from gulp build task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,11 +49,6 @@ function hugoDev(callback) {
   callback();
 }
 
-function hugoProd(callback) {
-  hugo(false);
-  callback();
-}
-
 exports.build = series(envProd, sass, js.transpileJS, js.concatJS);
 
 exports.serve = series(hugoDev, watchFiles);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -54,6 +54,6 @@ function hugoProd(callback) {
   callback();
 }
 
-exports.build = series(envProd, sass, js.transpileJS, js.concatJS, hugoProd);
+exports.build = series(envProd, sass, js.transpileJS, js.concatJS);
 
 exports.serve = series(hugoDev, watchFiles);


### PR DESCRIPTION
When fixing the previous `public` folder related issue (#147), I forgot to take into account the way the Bamboo plan works. I have removed the `hugoProd` piece from the Gulp build task, and it now runs correctly. 