### PR TITLE
Added new eol blog post

### DIFF
--- a/content/blog/rivet-1-end-of-life-plan.md
+++ b/content/blog/rivet-1-end-of-life-plan.md
@@ -7,7 +7,7 @@ author:
   email: "lmcgrana@iu.edu"
   name: "Levi McGranahan"
 ---
-As we begin work on Rivet 2 we want to make sure and communicate our current plans for how we will eventually retire the current major version of Rivet.
+As we begin work on [Rivet 2](https://v2.rivet.iu.edu) we want to make sure and communicate our current plans for how we will eventually retire the current major version of Rivet.
 
 **NOTE**: These are our current plans, but they may be subject to change. Generally speaking, we will do our best to allow _more_ time for migration and support of Rivet 1.x.x, not less.
 

--- a/content/blog/rivet-1-end-of-life-plan.md
+++ b/content/blog/rivet-1-end-of-life-plan.md
@@ -1,0 +1,38 @@
+---
+title: Rivet 1.x.x End of Life Plan
+description: "An overview of how we plan to retire Rivet 1"
+date: "2020-01-17"
+excludeFromIndex: true
+author:
+  email: "lmcgrana@iu.edu"
+  name: "Levi McGranahan"
+---
+As we begin work on Rivet 2 we want to make sure and communicate our current plans for how we will eventually retire the current major version of Rivet.
+
+**NOTE**: These are our current plans, but they may be subject to change. Generally speaking, we will do our best to allow _more_ time for migration and support of Rivet 1.x.x, not less.
+
+## Quick glossary of terms
+- We use the terms _Rivet 1.x.x_ and _Rivet 1_ to refer to the most current version of Rivet, and any version number beginning with `1`. From here on out they will be used interchangeably. 
+- We use the terms _Rivet 2.x.x_ and _Rivet 2_ to refer to the next major version of Rivet that we have begun working on. From here on out they will be used interchangeably.
+- [_End-of-Life_ plan](https://en.wikipedia.org/wiki/End-of-life_(product)) is a term commonly used to refer to how versions of software or other products are retired after being replace by newer versions. We'll use the abbreviation _EOL_ to refer to the _End-of-Life_ plan.
+
+## Concurrent documentation availability
+After the Rivet 2.0 release there will be a period of time during which Rivet 1.x.x documentation and Rivet 2.0 documentation will need to be available. During development, Rivet 2.0 documentation will live at the URL [v2.rivet.iu.edu](https://v2.rivet.iu.edu/) (while Rivet 1.x.x is maintained at [rivet.iu.edu](https://rivet.iu.edu/)). Once Rivet 2.0 is released, **Rivet 2.0 will move to the URL rivet.iu.edu and the Rivet 1.x.x docs will move to v1.rivet.iu.edu**. 
+
+## Migration period
+There will be a period of time post Rivet 2.0 release when developers will be able to continue using Rivet 1.x.x while migrating their websites and applications to Rivet 2.0. 
+
+The beginning of Rivet 2.0 development was announced in October of 2019. The Rivet 2.0.0-alpha releases are planned to start in December of 2019. This will give developers a minimum of 2 months of awareness between the Rivet 2.0 announcement and the start of alpha releases. Though we are unsure of exactly how long it will take between the alpha release and the full 2.0.0 release our current estimate is 6–9 months. Overall this creates a cushion of **~8–11 months before the migration period would begin**.
+
+Given this extended period of fore-knowledge surrounding the release of Rivet 2.0.0, our current plan is a **migration period of 12-18 months**. At the beginning of this period, we will release a migration guide. In more practical terms that means given our plan to release Rivet 2.0.0 by summer 2020, Rivet 1.x.x will be supported with any critical bug or accessibility fixes through the fall semester of 2021.
+
+## Rivet 1.x.x Documentation archival
+Once the migration period has ended, we plan to archive the Rivet 1.x.x documentation at a new permanent URL (v1.rivet.iu.edu) where it will continue to be available for those who still need to refer to it.
+
+## Development milestones
+As we continue development on Rivet 2, the Rivet team will continue to communicate important milestones and updates through [the blog](https://rivet.iu.edu/blog/) on the current Rivet website as well as our email list and Slack channels.
+
+## Questions
+If you have questions about the retirement of Rivet 1.x.x or the development of Rivet 2, head over to the Rivet Slack channels for the [IU Web Community of Practice](https://iuwebcommunity.slack.com/messages/rivet), or [UITS](https://iu-uits.slack.com/messages/service-rivet).
+
+You can also send a message to the [Rivet mailing list](mailto:rivet-l@list.iu.edu).


### PR DESCRIPTION
This PR adds a new blog post with info about the eventual _retirement_ of Rivet 1.x.x and the launch of Rivet 2.